### PR TITLE
71 add api token to database when logging conversation or user id if forced logged in or both

### DIFF
--- a/app/api/utils/auth.py
+++ b/app/api/utils/auth.py
@@ -1,12 +1,17 @@
 import os
 import jwt
 from flask import g
+from utils.oauth_validation import OAuth2TokenValidation
 
 from flask_httpauth import HTTPTokenAuth
 
-__all__ = [ "auth" ]
+__all__ = [ "auth", "user_ad" ]
 
 auth = HTTPTokenAuth(header='X-API-Key')
+user_ad = HTTPTokenAuth(header='Authorization', scheme='Bearer')
+
+tenant_id = os.getenv('AZURE_AD_TENANT_ID')
+client_id = os.getenv('AZURE_AD_CLIENT_ID')
 
 secret = os.getenv('JWT_SECRET', 'secret')
 
@@ -32,3 +37,14 @@ def verify_token(token):
 @auth.get_user_roles
 def get_user_roles(user):
     return g.roles
+
+@user_ad.verify_token
+def verify_user_access_token(token):
+    try:
+        oauth_validator = OAuth2TokenValidation(tenant_id, client_id)
+        user = oauth_validator.validate_token_and_decode_it(token)
+        if user:
+            return True
+    except Exception as e:
+        print(e)
+        return False

--- a/app/api/utils/auth.py
+++ b/app/api/utils/auth.py
@@ -46,5 +46,4 @@ def verify_user_access_token(token):
         if user:
             return True
     except Exception as e:
-        print(e)
         return False

--- a/app/api/utils/db.py
+++ b/app/api/utils/db.py
@@ -1,11 +1,12 @@
-import os
+import copy
 import json
 import logging
+import os
+from typing import Any
+import uuid
+
 from azure.data.tables import TableServiceClient
 from azure.identity import DefaultAzureCredential
-import uuid
-import copy
-
 from utils.models import Completion, Feedback, MessageRequest
 
 __all__ = ["store_request", "store_completion", "leave_feedback", "flag_conversation"]
@@ -20,7 +21,7 @@ chat_table_client = table_service_client.get_table_client(table_name="chat")
 feedback_table_client = table_service_client.get_table_client(table_name="feedback")
 flagged_client = table_service_client.get_table_client(table_name="flagged")
 
-def create_entity(data, partition_key: str, row_key_prefix: str):
+def create_entity(data, partition_key: str, row_key_prefix: str, user: Any):
     '''
     Create entity that we will store in the database
 
@@ -30,6 +31,11 @@ def create_entity(data, partition_key: str, row_key_prefix: str):
     entity = dict()
     entity['PartitionKey'] = partition_key
     entity['RowKey'] = f"{row_key_prefix}-{uuid.uuid4()}"
+
+    if user and user['oid'] and user['sub'] and user['prefered_username']:
+        entity['oid'] = user['oid']
+        entity['sub'] = user['sub']
+        entity['prefered_username'] = user['prefered_username']
 
     if isinstance(data_copy, Completion):
         entity['Answer'] = data_copy.message.content
@@ -48,7 +54,7 @@ def create_entity(data, partition_key: str, row_key_prefix: str):
 
     return entity
 
-def store_request(message_request: MessageRequest, conversation_uuid: str):
+def store_request(message_request: MessageRequest, conversation_uuid: str, user: Any):
       '''
       Store the conversation in the database, we store what we received (history and question) 
 
@@ -56,12 +62,12 @@ def store_request(message_request: MessageRequest, conversation_uuid: str):
             one solution is to compress and split the data: https://github.com/mebjas/AzureStorageTableLargeDataWriter/blob/master/AzureStorageTableLargeDataWriter/StorageTableWriter.cs
       '''
       try:
-        message_request_entity = create_entity(message_request, conversation_uuid, 'MessageRequest')
+        message_request_entity = create_entity(message_request, conversation_uuid, 'MessageRequest', user)
         chat_table_client.upsert_entity(message_request_entity)
       except Exception as e:
           logger.error(e)
 
-def store_completion(completion: Completion, conversation_uuid: str):
+def store_completion(completion: Completion, conversation_uuid: str, user: Any):
       '''
       Store the conversation in the database, we store the completion (answer)
 
@@ -69,7 +75,7 @@ def store_completion(completion: Completion, conversation_uuid: str):
             one solution is to compress and split the data: https://github.com/mebjas/AzureStorageTableLargeDataWriter/blob/master/AzureStorageTableLargeDataWriter/StorageTableWriter.cs
       '''
       try:
-        completion_entity = create_entity(completion, conversation_uuid, 'Completion')
+        completion_entity = create_entity(completion, conversation_uuid, 'Completion', user)
         chat_table_client.upsert_entity(completion_entity)
       except Exception as e:
           logger.error(e)
@@ -80,7 +86,7 @@ def leave_feedback(feedback: Feedback):
       '''
       try:
         convo_uuid = feedback.uuid if feedback.uuid else str(uuid.uuid4())
-        feedback_entity = create_entity(feedback, convo_uuid, 'Feedback')
+        feedback_entity = create_entity(feedback, convo_uuid, 'Feedback', None)
         feedback_table_client.upsert_entity(feedback_entity)
       except Exception as e:
           logger.error(e)
@@ -90,7 +96,7 @@ def flag_conversation(message_request: MessageRequest, conversation_uuid: str):
       Store the feedback in the database, we store what we received (history and question) and the completion (answer)
       '''
       try:
-        message_request_entity = create_entity(message_request, conversation_uuid, 'MessageRequest')
+        message_request_entity = create_entity(message_request, conversation_uuid, 'MessageRequest', None)
         flagged_client.upsert_entity(message_request_entity)
       except Exception as e:
           logger.error(e)

--- a/app/api/utils/oauth_validation.py
+++ b/app/api/utils/oauth_validation.py
@@ -1,0 +1,96 @@
+import time
+import jwt
+import base64
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+import json
+from urllib.request import urlopen
+
+class OAuth2TokenValidation:
+
+    def __init__(self, tenant_id, client_id):
+        # those are obtained via: https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration
+        self.jwks_url = f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys"
+        self.issuer_url = f"https://login.microsoftonline.com/{tenant_id}/v2.0"
+        #self.audience = f"api://{client_id}"
+        self.audience = client_id
+
+        self.jwks = json.loads(urlopen(self.jwks_url).read())
+        self.last_jwks_public_key_update = time.time()
+
+    def validate_token_and_decode_it(self, token):
+        """
+        :param token: the jwt token to validate
+        :return: the decoded token if valid, else raises an exception
+        """
+
+        try:
+            unverified_header = jwt.get_unverified_header(token)
+            print(f"HEADERS: {unverified_header}")
+        except Exception as e:
+            raise Exception(f"Unable to decode authorization token headers: {e}")
+
+        try:
+            rsa_key = OAuth2TokenValidation.find_rsa_key(self.jwks, unverified_header)
+            print(rsa_key)
+            public_key = OAuth2TokenValidation.rsa_pem_from_jwk(rsa_key)
+            print(public_key)
+
+            print(token)
+
+            return jwt.decode(
+              token,
+              public_key,
+              verify=True,
+              algorithms=["RS256"],
+              audience=self.audience,
+              issuer=self.issuer_url
+            )
+
+        except jwt.ExpiredSignatureError:
+            raise Exception("Token has expired")
+        except jwt.InvalidTokenError as e:
+            print(e)
+            raise Exception("Invalid token")
+        except Exception as e:
+            # update the public key if not fresh and try again
+            if int(time.time() - self.last_jwks_public_key_update) > 60:
+                self.jwks = json.loads(urlopen(self.jwks_url).read())
+                self.last_jwks_public_key_update = time.time()
+                return self.validate_token_and_decode_it(token)
+            else:
+                print(f"Error validating token: {e}")
+
+    @staticmethod
+    def find_rsa_key(jwks, unverified_header):
+        for key in jwks["keys"]:
+            if key["kid"] == unverified_header["kid"]:
+                return {
+                  "kty": key["kty"],
+                  "kid": key["kid"],
+                  "use": key["use"],
+                  "n": key["n"],
+                  "e": key["e"]
+                }
+
+    @staticmethod
+    def ensure_bytes(key):
+        if isinstance(key, str):
+            key = key.encode('utf-8')
+        return key
+
+    @staticmethod
+    def decode_value(val):
+        decoded = base64.urlsafe_b64decode(OAuth2TokenValidation.ensure_bytes(val) + b'==')
+        return int.from_bytes(decoded, 'big')
+
+    @staticmethod
+    def rsa_pem_from_jwk(jwk):
+        return RSAPublicNumbers(
+            n=OAuth2TokenValidation.decode_value(jwk['n']),
+            e=OAuth2TokenValidation.decode_value(jwk['e'])
+        ).public_key(default_backend()).public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )

--- a/app/api/utils/oauth_validation.py
+++ b/app/api/utils/oauth_validation.py
@@ -13,7 +13,6 @@ class OAuth2TokenValidation:
         # those are obtained via: https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration
         self.jwks_url = f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys"
         self.issuer_url = f"https://login.microsoftonline.com/{tenant_id}/v2.0"
-        #self.audience = f"api://{client_id}"
         self.audience = client_id
 
         self.jwks = json.loads(urlopen(self.jwks_url).read())
@@ -27,17 +26,12 @@ class OAuth2TokenValidation:
 
         try:
             unverified_header = jwt.get_unverified_header(token)
-            print(f"HEADERS: {unverified_header}")
         except Exception as e:
             raise Exception(f"Unable to decode authorization token headers: {e}")
 
         try:
             rsa_key = OAuth2TokenValidation.find_rsa_key(self.jwks, unverified_header)
-            print(rsa_key)
             public_key = OAuth2TokenValidation.rsa_pem_from_jwk(rsa_key)
-            print(public_key)
-
-            print(token)
 
             return jwt.decode(
               token,
@@ -51,7 +45,6 @@ class OAuth2TokenValidation:
         except jwt.ExpiredSignatureError:
             raise Exception("Token has expired")
         except jwt.InvalidTokenError as e:
-            print(e)
             raise Exception("Invalid token")
         except Exception as e:
             # update the public key if not fresh and try again

--- a/app/api/utils/oauth_validation.py
+++ b/app/api/utils/oauth_validation.py
@@ -8,6 +8,9 @@ import json
 from urllib.request import urlopen
 
 class OAuth2TokenValidation:
+    """
+    Code taken from SO: https://stackoverflow.com/questions/76886257/how-to-validate-access-token-from-azuread-in-python
+    """
 
     def __init__(self, tenant_id, client_id):
         # those are obtained via: https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration

--- a/app/api/v1/routes_v1.py
+++ b/app/api/v1/routes_v1.py
@@ -10,7 +10,7 @@ from utils.db import store_completion, store_request, leave_feedback, flag_conve
 from utils.models import Completion, Feedback, MessageRequest
 from utils.openai import (build_completion_response, chat_with_data,
                           convert_chat_with_data_response)
-from utils.auth import auth
+from utils.auth import auth, user_ad
 import uuid
 import threading
 
@@ -56,6 +56,7 @@ _boundary = "GPT-Interaction"
 })
 @api_v1.doc(security='ApiKeyAuth')
 @auth.login_required(role='chat')
+@user_ad.login_required
 def completion_chat(message_request: MessageRequest):
     if not message_request.query and not message_request.messages:
         return jsonify({"error":"Request body must at least contain messages (conversation) or a query (direct question)."}), 400
@@ -89,6 +90,7 @@ def completion_chat(message_request: MessageRequest):
 @api_v1.output(Completion.Schema, content_type=f'multipart/x-mixed-replace; boundary={_boundary}') # type: ignore
 @api_v1.doc(security='ApiKeyAuth')
 @auth.login_required(role='chat')
+@user_ad.login_required
 def completion_chat_stream(message_request: MessageRequest):
     if not message_request.query and not message_request.messages:
         return jsonify({"error":"Request body must at least contain messages (conversation) or a query (direct question)."}), 400

--- a/app/api/v1/routes_v1.py
+++ b/app/api/v1/routes_v1.py
@@ -96,7 +96,8 @@ def completion_chat_stream(message_request: MessageRequest):
         return jsonify({"error":"Request body must at least contain messages (conversation) or a query (direct question)."}), 400
     
     convo_uuid = message_request.uuid if message_request.uuid else str(uuid.uuid4())
-    thread = threading.Thread(target=store_request, args=(message_request, convo_uuid))
+    user = user_ad.current_user()
+    thread = threading.Thread(target=store_request, args=(message_request, convo_uuid, user))
     thread.start()
     try:
         completion: ChatCompletion | Stream[ChatCompletionChunk] = chat_with_data(message_request, stream=True)

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -130,7 +130,8 @@ export const App = () => {
     try {
       const completionResponse = await completionMySSC({
         request: request,
-        updateLastMessage: updateLastMessage
+        updateLastMessage: updateLastMessage,
+        accessToken: instance.getActiveAccount()?.idToken || ""
       });
 
       setCompletions((prevCompletions) => {
@@ -270,7 +271,8 @@ export const App = () => {
     try {
       const completionResponse = await completionMySSC({
         request: request,
-        updateLastMessage: updateLastMessage
+        updateLastMessage: updateLastMessage,
+        accessToken: instance.getActiveAccount()?.idToken || ""
       });
 
       setCompletions((prevCompletions) => {

--- a/app/frontend/src/api/api.ts
+++ b/app/frontend/src/api/api.ts
@@ -1,16 +1,18 @@
 interface CompletionProps {
   request: MessageRequest;
   updateLastMessage: (message_chunk: string) => void;
+  accessToken: string;
 }
 
-export async function completionMySSC({ request, updateLastMessage }: CompletionProps): Promise<Completion> {
+export async function completionMySSC({ request, updateLastMessage, accessToken }: CompletionProps): Promise<Completion> {
   let completion: Completion | undefined;
 
   let url = "/api/1.0/completion/chat/stream";
   const response = await fetch(url, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      "Authorization": "Bearer " + accessToken.trim()
     },
     body: JSON.stringify(request)
   });


### PR DESCRIPTION
semi temp solution that decodes and verify the `id token` of the logged in user to store the `oid` and `sub` props from the jwt token in the database when logging messages/conversation.

This is the first phase. The next iteration should aim to:

1. properly setup/modifiy an app registrsation with proper API scopes for our API
2. remove the API dual validation of `flask_httpauth` to migrate from reading from two headers down to just the `Authorization Bearer` token. 
3. frontend would have the user request for a access token that would contain the proper scope(s) for the API
4. setup necessary TF configuration for dev domain (along with everything so far) so we can replicate on "prod'