### PR TITLE
fix header background transparency, adjust header width

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -365,13 +365,13 @@ export const App = () => {
               minHeight: "100vh",
               margin: "auto",
             }}
-            maxWidth="lg"
+            maxWidth="lg" 
           >
             <Box sx={{ flexGrow: 1 }}></Box>
             <Box
               sx={{
                 overflowY: "hidden",
-                padding: "2rem",
+                padding: "3rem",
                 paddingTop: "6rem",
                 alignItems: "flex-end",
               }}

--- a/app/frontend/src/components/TopMenu.tsx
+++ b/app/frontend/src/components/TopMenu.tsx
@@ -28,16 +28,16 @@ export const TopMenu = ({ toggleDrawer } : TopMenuProps) => {
       <AppBar
         position="fixed"
         sx={{
-          bgcolor: "transparent",
+          bgcolor: "white",
           backgroundImage: "none",
           boxShadow: "none",
-          mt: { xs: 0, sm: 2 },
+          pt: { xs: 0, sm: 2 },
         }}
       >
         <Toolbar
           variant="regular"
           sx={(theme) => ({
-            width: { xs: "100%", sm: "75%" },
+            width: { xs: "100%", sm: "95%", xl: "75%" },
             margin: "auto",
             display: "flex",
             alignItems: "center",


### PR DESCRIPTION
This pull request fixes an issue where the space above the header was transparent and thus chat bubbles were visible above it. 