### PR TITLE
change chatHistories state to single chatHistory

### DIFF
--- a/app/frontend/src/components/AssistantBubble.tsx
+++ b/app/frontend/src/components/AssistantBubble.tsx
@@ -81,6 +81,10 @@ export const AssistantBubble = ({ text, isLoading, context, toolsInfo, scrollRef
         setProcessedContent({ processedText, citedCitations });
         setCitationNumberMapping(citationNumberMapping); // store the citationNumberMapping in state
         setProcessingComplete(true);
+    } else {
+      setProcessedContent({processedText: "", citedCitations: []});
+      setCitationNumberMapping({});
+      setProcessingComplete(false);
     }
 }, [isLoading, context, text, scrollRef]);
 
@@ -103,6 +107,8 @@ export const AssistantBubble = ({ text, isLoading, context, toolsInfo, scrollRef
       if (toolsInfo && toolsInfo.payload?.hasOwnProperty("profiles") && toolsInfo.payload.profiles !== null) {
           const processedProfiles = processProfiles(toolsInfo.payload.profiles);
           setProfiles(processedProfiles);
+      } else {
+        setProfiles([]);
       }
   }, [toolsInfo]);
 

--- a/app/frontend/src/components/DrawerMenu.tsx
+++ b/app/frontend/src/components/DrawerMenu.tsx
@@ -41,7 +41,7 @@ import React from "react";
 
 interface DrawerMenuProps {
   openDrawer: boolean;
-  chatHistories: ChatHistory[];
+  chatDescriptions: string[];
   currentChatIndex: number;
   toggleDrawer: (arg: boolean) => void;
   onClearChat: () => void;
@@ -59,7 +59,7 @@ interface DrawerMenuProps {
   renameChat: (newChatDescription: string, index: number) => void;
 }
 
-export const DrawerMenu = ({openDrawer, chatHistories, toggleDrawer, onClearChat, onNewChat, setLangCookie, 
+export const DrawerMenu = ({openDrawer, chatDescriptions, toggleDrawer, onClearChat, onNewChat, setLangCookie, 
   logout, enabledTools, handleUpdateEnabledTools, handleSelectedModelChanged, selectedModel, tutorialBubbleNumber, handleToggleTutorials,
   handleDeleteSavedChat, handleLoadSavedChat, renameChat, currentChatIndex} : DrawerMenuProps) => {
   const [toolMenuOpen, setToolMenuOpen] = useState(false);
@@ -101,8 +101,8 @@ export const DrawerMenu = ({openDrawer, chatHistories, toggleDrawer, onClearChat
   }
 
   const handleRenameClicked = () => {
-    if (selectedChatIndex !== null && chatHistories[selectedChatIndex].description) {
-      setEditedDescription(chatHistories[selectedChatIndex].description);
+    if (selectedChatIndex !== null && chatDescriptions[selectedChatIndex]) {
+      setEditedDescription("");
     }
     setEditingIndex(selectedChatIndex);
     setTextFieldIsFocused(true);
@@ -289,7 +289,7 @@ export const DrawerMenu = ({openDrawer, chatHistories, toggleDrawer, onClearChat
         </ListItem>
         <Collapse in={selectChatMenuOpen} timeout="auto" unmountOnExit>
           <Divider />
-          {chatHistories.map((chatHistory, index) => {
+          {chatDescriptions.map((chatDescription, index) => {
             return (
               <ListItem key={index} 
                 sx={{
@@ -413,7 +413,7 @@ export const DrawerMenu = ({openDrawer, chatHistories, toggleDrawer, onClearChat
                         textOverflow: 'ellipsis',
                       }}
                     >
-                      {chatHistory.description ? chatHistory.description : "Conversation " + (index + 1)}
+                      {chatDescription}
                     </Typography>
                   </ListItemButton>
                 }

--- a/app/frontend/src/i18n/locales/translations.json
+++ b/app/frontend/src/i18n/locales/translations.json
@@ -89,7 +89,7 @@
     },
     "clear.conversation": {
         "en": "Clear Current Chat",
-        "fr": "Effacer la Conversation Actuelle"
+        "fr": "Effacer la conversation actuelle"
     },
     "toolsUsed": {
         "en": "Tools used by the assistant in the response",
@@ -293,7 +293,7 @@
     },
     "menu.chooseTools": {
         "en": "Select Tools",
-        "fr": "Sélectionnez les Outils"
+        "fr": "Sélectionnez les outils"
     },
     "menu.title": {
         "en": "Configure answer generation",
@@ -393,7 +393,7 @@
     },
     "model.version.select": {
         "en": "Select Model Version",
-        "fr": "Sélectionnez la Version du Modèle"
+        "fr": "Sélectionnez la version du modèle"
     },
     "tutorial.menu": {
         "en": "Use the menu to view customization settings, change language, clear chat, and more.",
@@ -465,7 +465,7 @@
     },
     "select.conversation": {
         "en": "Select Conversation",
-        "fr": "Sélectionnez la Conversation"
+        "fr": "Sélectionnez la conversation"
     },
     "delete": {
         "en": "Delete",
@@ -477,7 +477,7 @@
     },
     "delete.conversation.title": {
         "en": "Delete Conversation",
-        "fr": "Supprimer la Conversation"
+        "fr": "Supprimer la conversation"
     },
     "delete.conversation.content": {
         "en": "Are you sure you want to delete this conversation?",
@@ -489,7 +489,7 @@
     },
     "new.conversation": {
         "en": "New Conversarion",
-        "fr": "Nouvelle Conversation"
+        "fr": "Nouvelle conversation"
     },
     "drawer.header.conversations": {
         "en": "Conversations",
@@ -497,7 +497,7 @@
     },
     "drawer.header.toolsAndModels": {
         "en": "Tools and Models",
-        "fr": "Outils et Modèles"
+        "fr": "Outils et modèles"
     },
     "storage.full": {
         "en": "Warning: Your storage is full. Please delete or clear a conversation/conversations to continue.",

--- a/app/frontend/src/screens/MainScreen.tsx
+++ b/app/frontend/src/screens/MainScreen.tsx
@@ -118,14 +118,20 @@ const MainScreen = ({userData}: MainScreenProps) => {
                         };
                     }
                     return item;
-                }).filter(item => !isAToastMessage(item));
+                });
 
                 const updatedChatHistory: ChatHistory = {
                     ...prevChatHistory,
                     chatItems: updatedChatItems
                 };
 
-                saveChatHistories(updatedChatHistory);
+                // filters toast messages so they're not saved to local storage
+                const filteredChatHistory = {
+                    ...updatedChatHistory,
+                    chatItems: updatedChatItems.filter(item => !isAToastMessage(item))
+                }
+
+                saveChatHistories(filteredChatHistory);
                 return updatedChatHistory;
             });
 

--- a/app/frontend/src/screens/MainScreen.tsx
+++ b/app/frontend/src/screens/MainScreen.tsx
@@ -540,6 +540,9 @@ const MainScreen = ({userData}: MainScreenProps) => {
         };
         updatedChatHistories[indexToUpdate] = updatedChatHistory;
         localStorage.setItem("chatHistories", JSON.stringify(updatedChatHistories));
+        if (currentChatIndex === indexToUpdate) {
+            setCurrentChatHistory(updatedChatHistory);
+        }
         setChatHistoriesDescriptions(updatedChatHistories.map((chatHistory, index) => chatHistory.description || "Conversation " + (index + 1)));
     }
     


### PR DESCRIPTION
This PR changes the previous chatHistories state as an array of chatHistory objects to just a single chatHistory. This simplifies the state updates for a chatHistory while also maintaining the multiple conversation capabilities thru localStorage.