### PR TITLE
Impliment Github Code Scanning 

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -1,10 +1,6 @@
 name: Code Scanning
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
   schedule:
     - cron: '0 10 * * *'
   workflow_dispatch:  

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -1,9 +1,12 @@
 name: Code Scanning
 
 on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   schedule:
-    - cron: '0 10 * * *'
-  workflow_dispatch:  
+    - cron: '15 13 * * 5'
 
 permissions:
   contents: read

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Security Issue
+
+**Do not post security issues to our public repositories.**  
+If you discover a security vulnerability, please report it privately by contacting the repository owner. To contact the owner, visit the [repository's owner page](https://github.com/OWNER_NAME) and send a direct message. We take security issues seriously and will respond promptly to assess and address the issue.
+
+### Contact Information:
+- Contact the repository owner via their GitHub profile.
+
+______________________
+
+# Politique de Sécurité
+
+## Signaler un problème de sécurité
+
+**Ne publiez pas de problèmes de sécurité dans nos dépôts publics.**  
+Si vous découvrez une vulnérabilité de sécurité, veuillez la signaler de manière privée en contactant le propriétaire du dépôt. Pour contacter le propriétaire, visitez la [page du propriétaire du dépôt](https://github.com/OWNER_NAME) et envoyez un message direct. Nous prenons les problèmes de sécurité au sérieux et répondrons rapidement pour évaluer et résoudre le problème.
+
+### Coordonnées :
+- Contactez le propriétaire du dépôt via leur profil GitHub.


### PR DESCRIPTION
Created a github action to perform code scanning(using trivy) and to flag those issues directly to the repo owner. 
Github alerts needs to be enabled. 

Scan will run on 
- Daily at 10am
- Manually(adhoc)

Potential vulnerabilities will be flagged under the security tab in github, viewable only to the the repo users.

Repo owner will need to modify the SECURITY.md document for their needs

Security Report
For Example:
![image](https://github.com/user-attachments/assets/4a9eab06-44e7-4feb-aace-0f62f1db1c1e)

Scan will not block code commits.
