### PR TITLE
730 citations not displayed even when returned in payload

### DIFF
--- a/app/api/requirements.txt
+++ b/app/api/requirements.txt
@@ -1,12 +1,12 @@
-azure-identity
-azure-keyvault-secrets
-azure-storage-blob
+azure-identity==1.25.1
+azure-keyvault-secrets==4.10.0
+azure-storage-blob==12.27.1
 azure-search-documents==11.6.0b2
-azure-data-tables 
+azure-data-tables==12.7.0 
 apiflask
 Flask
 gunicorn
-openai
+openai==2.8.1
 python-dotenv
 bs4
 marshmallow_dataclass

--- a/app/api/tools/pmcoe/pmcoe_prompts.py
+++ b/app/api/tools/pmcoe/pmcoe_prompts.py
@@ -414,7 +414,7 @@ Here is a list of common acronyms and their meanings that you can use to assist 
 
 """
 
-# REMARQUE : même directive que la version anglaise — forcer les citations à
+# REMARQUE : même directive que la version anglaise — forcer les citations à
 # utiliser les titres précis afin qu'elles restent exploitables en interface.
 PMCOE_SYSTEM_PROMPT_FR = """Vous êtes un assistant IA qui aide les employés de Services partagés Canada (SPC) avec le contenu du Centre d’excellence en gestion de projet (CEGP).
 

--- a/app/api/tools/pmcoe/pmcoe_prompts.py
+++ b/app/api/tools/pmcoe/pmcoe_prompts.py
@@ -1,3 +1,5 @@
+# NOTE: This prompt mandates explicit document-level citations so the UI can
+# render clickable references instead of generic placeholders.
 PMCOE_SYSTEM_PROMPT_EN = """You are an AI assistant helping Shared Services Canada (SSC) employees with Project Management Center of Excellence (PMCOE) content.
 You provide information related to project management, gate templates, and standardized templates to support consistent project delivery and documentation.
 
@@ -36,7 +38,7 @@ UNCERTAINTY HANDLING
 - If a definitive answer is not possible with current sources, state what is known, what is unknown, and what to consult next.
 
 CITATIONS
-- Where feasible, reference source document titles or identifiers returned by the retrieval layer (e.g., "(Source: PMCOE index)").
+- Always reference the specific document titles or identifiers returned by the retrieval layer (e.g., "(Source: Project Charter Template – EN)") and avoid generic placeholders such as "PMCOE index".
 
 Here is a list of common acronyms and their meanings that you can use to assist users:
 
@@ -412,6 +414,8 @@ Here is a list of common acronyms and their meanings that you can use to assist 
 
 """
 
+# REMARQUE : même directive que la version anglaise — forcer les citations à
+# utiliser les titres précis afin qu'elles restent exploitables en interface.
 PMCOE_SYSTEM_PROMPT_FR = """Vous êtes un assistant IA qui aide les employés de Services partagés Canada (SPC) avec le contenu du Centre d’excellence en gestion de projet (CEGP).
 
 Vous fournissez des informations liées à la gestion de projet, aux gabarits de portes (gates) et aux modèles normalisés pour soutenir une exécution et une documentation cohérentes des projets.
@@ -450,7 +454,7 @@ GESTION DE L’INCERTITUDE
 - Si une réponse définitive n’est pas possible, indiquez ce qui est connu, ce qui ne l’est pas et la prochaine source à consulter.
 
 CITATIONS
-- Lorsque possible, faites référence aux titres ou identifiants des documents sources renvoyés (ex. : « (Source : index PMCOE) »).
+- Référencez toujours les titres ou identifiants précis des documents sources renvoyés (p. ex., « (Source : Modèle de charte de projet – FR) ») et évitez les libellés génériques tels que « index PMCOE ».
 
 Voici une liste d’acronymes courants et leurs significations que vous pouvez utiliser pour aider les utilisateurs :
 

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@azure/msal-browser": "^3.10.0",
-        "@azure/msal-react": "^2.0.12",
+        "@azure/msal-browser": "^4.26.2",
+        "@azure/msal-react": "^3.0.22",
         "@azure/openai": "^2.0.0",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
@@ -276,37 +276,37 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.28.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.28.1.tgz",
-      "integrity": "sha512-OHHEWMB5+Zrix8yKvLVzU3rKDFvh7SOzAzXfICD7YgUXLxfHpTPX2pzOotrri1kskwhHqIj4a5LvhZlIqE7C7g==",
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.26.2.tgz",
+      "integrity": "sha512-F2U1mEAFsYGC5xzo1KuWc/Sy3CRglU9Ql46cDUx8x/Y3KnAIr1QAq96cIKCk/ZfnVxlvprXWRjNKoEpgLJXLhg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.16.0"
+        "@azure/msal-common": "15.13.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "14.16.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.0.tgz",
-      "integrity": "sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==",
+      "version": "15.13.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.13.2.tgz",
+      "integrity": "sha512-cNwUoCk3FF8VQ7Ln/MdcJVIv3sF73/OT86cRH81ECsydh7F4CNfIo2OAx6Cegtg8Yv75x4506wN4q+Emo6erOA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-react": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-2.2.0.tgz",
-      "integrity": "sha512-2V+9JXeXyyjYNF92y5u0tU4el9px/V1+vkRuN+DtoxyiMHCtYQpJoaFdGWArh43zhz5aqQqiGW/iajPDSu3QsQ==",
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-3.0.22.tgz",
+      "integrity": "sha512-ZiNr/uQr0f28UGcrMdlBNRlMzA7Mzp0sW4eOR7/rmVBykv4shT2y6PG5+CDCQlSL+AAdoR8pYbaOkuAtPR+37g==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@azure/msal-browser": "^3.27.0",
-        "react": "^16.8.0 || ^17 || ^18"
+        "@azure/msal-browser": "^4.26.2",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@azure/openai": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -11,8 +11,8 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@azure/msal-browser": "^3.10.0",
-    "@azure/msal-react": "^2.0.12",
+    "@azure/msal-browser": "^4.26.2",
+    "@azure/msal-react": "^3.0.22",
     "@azure/openai": "^2.0.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",

--- a/app/frontend/src/components/AssistantBubble.tsx
+++ b/app/frontend/src/components/AssistantBubble.tsx
@@ -137,6 +137,8 @@ export const AssistantBubble = ({
               const [baseUrl, hash] = href.split("#");
               const docMatch = hash?.match(/citation-(\d+)/i);
               const docNumber = docMatch ? parseInt(docMatch[1], 10) : undefined;
+              // If the href targets one of our generated inline citations, open
+              // the drawer locally rather than navigating away to SharePoint.
               if (openCitationByUrl(baseUrl, docNumber)) {
                 e.preventDefault();
               }
@@ -225,6 +227,11 @@ export const AssistantBubble = ({
   // Helper: open drawer by URL found in inline links
   const [pendingCitationNumber, setPendingCitationNumber] = useState<number | null>(null);
 
+  /**
+   * Opens the citation drawer for the provided URL and optionally records the
+   * inline citation number we should scroll to once the drawer finishes
+   * animating into view.
+   */
   const openCitationByUrl = (url?: string, citationNumber?: number) => {
     if (!url || !processedContent.citedCitations?.length) return false;
     const decoded = safeDecode(url);

--- a/app/frontend/src/components/AssistantBubble.tsx
+++ b/app/frontend/src/components/AssistantBubble.tsx
@@ -29,6 +29,7 @@ import { useEffect, useState, Fragment, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { BubbleButtons } from "./BubbleButtons";
 import { styled } from "@mui/system";
+import type { Theme } from "@mui/material/styles";
 import ProfileCardsContainer from "../containers/ProfileCardsContainer";
 import HandymanIcon from "@mui/icons-material/Handyman";
 import logo from "../assets/SSC-Logo-Purple-Leaf-300x300.png";
@@ -1154,13 +1155,16 @@ const ChatBubbleInner = styled(Paper)(() => ({
   maxWidth: "95%",
 }));
 
-const CitationInlinePanel = styled(Box)(({ theme }) => ({
-  marginTop: theme.spacing(2),
-  borderRadius: theme.shape.borderRadius,
-  border: `1px solid ${theme.palette.divider}`,
-  backgroundColor: theme.palette.background.paper,
-  boxShadow: theme.shadows[2],
-}));
+const CitationInlinePanel = styled(Box)(({ theme }) => {
+  const muiTheme = theme as Theme;
+  return {
+    marginTop: muiTheme.spacing(2),
+    borderRadius: muiTheme.shape.borderRadius,
+    border: `1px solid ${muiTheme.palette.divider}`,
+    backgroundColor: muiTheme.palette.background.paper,
+    boxShadow: muiTheme.shadows[2],
+  };
+});
 
 const ToolsUsedBox = styled(Box)`
   display: flex;


### PR DESCRIPTION
- PMCOE prompts now require exact document titles or IDs in citations. This removes vague labels like “PMCOE index” and ensures the backend returns usable citation metadata for the UI.

- AssistantBubble shows only the sources the assistant actually cites. It still supports [docX] markers, and if those are missing, it detects “Source: …” mentions by normalizing titles, file paths, or filenames and matching them to the reply. Only matched sources appear in the chips and drawer.

- Added inline documentation explaining the new helpers and why explicit titles and alias matching are needed.

- Upgraded authentication libraries to improve stability/security: @azure/msal-browser to ^4.26.2 and @azure/msal-react to ^3.0.22. and openai 2.8.1

- When clicking docx number it now autoscrolls to that citation number in the citations panel