### PR TITLE
Add chat waiting state management and UI updates in SessionSidebar

### DIFF
--- a/app/frontend/src/playground/components/SessionSidebar.integration.test.tsx
+++ b/app/frontend/src/playground/components/SessionSidebar.integration.test.tsx
@@ -9,6 +9,7 @@ vi.mock("react-use-measure", () => ({
 }));
 
 import SessionSidebar from "./SessionSidebar";
+import chatReducer from "../store/slices/chatSlice";
 import sessionReducer from "../store/slices/sessionSlice";
 import uiReducer, { toggleSidebarCollapsed } from "../store/slices/uiSlice";
 
@@ -25,6 +26,7 @@ vi.mock("./ProfileMenu/ProfileMenu", () => ({
 }));
 
 type TestStoreState = {
+  chat: ReturnType<typeof chatReducer>;
   sessions: ReturnType<typeof sessionReducer>;
   ui: ReturnType<typeof uiReducer>;
 };
@@ -33,12 +35,46 @@ type TestStoreState = {
  * Creates a minimal Redux harness for rendering SessionSidebar in isolation.
  */
 function renderSidebar(isMobile: boolean, preloadedState?: TestStoreState) {
+  const defaultState: TestStoreState = {
+    chat: {
+      messages: [],
+      isLoadingBySessionId: {},
+      assistantResponsePhaseBySessionId: {},
+      orchestratorInsightsBySessionId: {},
+    },
+    sessions: {
+      sessions: [],
+      currentSessionId: null,
+    },
+    ui: {
+      isSidebarCollapsed: false,
+      isMobileSidebarOpen: false,
+      isDeletingAllChats: false,
+    },
+  };
+
   const store = configureStore({
     reducer: {
+      chat: chatReducer,
       sessions: sessionReducer,
       ui: uiReducer,
     },
-    preloadedState,
+    preloadedState: {
+      ...defaultState,
+      ...preloadedState,
+      chat: {
+        ...defaultState.chat,
+        ...(preloadedState?.chat ?? {}),
+      },
+      sessions: {
+        ...defaultState.sessions,
+        ...(preloadedState?.sessions ?? {}),
+      },
+      ui: {
+        ...defaultState.ui,
+        ...(preloadedState?.ui ?? {}),
+      },
+    },
   });
 
   render(
@@ -57,6 +93,12 @@ describe("SessionSidebar responsive behavior", () => {
    */
   it("hides desktop sidebar when collapsed", () => {
     renderSidebar(false, {
+      chat: {
+        messages: [],
+        isLoadingBySessionId: {},
+        assistantResponsePhaseBySessionId: {},
+        orchestratorInsightsBySessionId: {},
+      },
       sessions: {
         sessions: [],
         currentSessionId: null,
@@ -78,6 +120,12 @@ describe("SessionSidebar responsive behavior", () => {
    */
   it("reacts to sidebar collapse state change", async () => {
     const store = renderSidebar(false, {
+      chat: {
+        messages: [],
+        isLoadingBySessionId: {},
+        assistantResponsePhaseBySessionId: {},
+        orchestratorInsightsBySessionId: {},
+      },
       sessions: {
         sessions: [],
         currentSessionId: null,
@@ -108,6 +156,12 @@ describe("SessionSidebar responsive behavior", () => {
     const user = userEvent.setup();
 
     const store = renderSidebar(true, {
+      chat: {
+        messages: [],
+        isLoadingBySessionId: {},
+        assistantResponsePhaseBySessionId: {},
+        orchestratorInsightsBySessionId: {},
+      },
       sessions: {
         sessions: [
           {
@@ -141,6 +195,12 @@ describe("SessionSidebar responsive behavior", () => {
 
   it("renders virtualized session options with listbox semantics", () => {
     renderSidebar(false, {
+      chat: {
+        messages: [],
+        isLoadingBySessionId: {},
+        assistantResponsePhaseBySessionId: {},
+        orchestratorInsightsBySessionId: {},
+      },
       sessions: {
         sessions: [
           {
@@ -173,6 +233,12 @@ describe("SessionSidebar responsive behavior", () => {
     const user = userEvent.setup();
 
     const store = renderSidebar(false, {
+      chat: {
+        messages: [],
+        isLoadingBySessionId: {},
+        assistantResponsePhaseBySessionId: {},
+        orchestratorInsightsBySessionId: {},
+      },
       sessions: {
         sessions: [
           {
@@ -237,6 +303,12 @@ describe("SessionSidebar responsive behavior", () => {
 
     try {
       renderSidebar(true, {
+        chat: {
+          messages: [],
+          isLoadingBySessionId: {},
+          assistantResponsePhaseBySessionId: {},
+          orchestratorInsightsBySessionId: {},
+        },
         sessions: {
           sessions: [
             {
@@ -269,6 +341,12 @@ describe("SessionSidebar responsive behavior", () => {
     const user = userEvent.setup();
 
     renderSidebar(true, {
+      chat: {
+        messages: [],
+        isLoadingBySessionId: {},
+        assistantResponsePhaseBySessionId: {},
+        orchestratorInsightsBySessionId: {},
+      },
       sessions: {
         sessions: [
           {
@@ -292,5 +370,61 @@ describe("SessionSidebar responsive behavior", () => {
     await waitFor(() => {
       expect((document.activeElement as HTMLElement | null)?.id).toBe("new-chat-button");
     });
+  });
+
+  it("marks waiting sessions in the title attributes", () => {
+    renderSidebar(false, {
+      chat: {
+        messages: [],
+        isLoadingBySessionId: { s1: true },
+        assistantResponsePhaseBySessionId: { s2: "drafting" },
+        orchestratorInsightsBySessionId: {},
+      },
+      sessions: {
+        sessions: [
+          {
+            id: "s1",
+            name: "Session 1",
+            createdAt: 1,
+            isNewChat: false,
+          },
+          {
+            id: "s2",
+            name: "Session 2",
+            createdAt: 2,
+            isNewChat: false,
+          },
+          {
+            id: "s3",
+            name: "Session 3",
+            createdAt: 3,
+            isNewChat: false,
+          },
+        ],
+        currentSessionId: "s3",
+      },
+      ui: {
+        isSidebarCollapsed: false,
+        isMobileSidebarOpen: false,
+        isDeletingAllChats: false,
+      },
+    });
+
+    expect(screen.getByTestId("session-title-s1")).toHaveAttribute("data-waiting-for-response", "true");
+    expect(screen.getByTestId("session-title-s2")).toHaveAttribute("data-waiting-for-response", "true");
+    expect(screen.getByTestId("session-title-s3")).toHaveAttribute("data-waiting-for-response", "false");
+
+    expect(document.getElementById("session-button-s1")).toHaveAttribute(
+      "aria-describedby",
+      "session-waiting-status-s1"
+    );
+    expect(document.getElementById("session-button-s2")).toHaveAttribute(
+      "aria-describedby",
+      "session-waiting-status-s2"
+    );
+    expect(document.getElementById("session-button-s3")).not.toHaveAttribute("aria-describedby");
+
+    expect(document.getElementById("session-waiting-status-s1")).toHaveTextContent("Waiting for AI response");
+    expect(document.getElementById("session-waiting-status-s2")).toHaveTextContent("Waiting for AI response");
   });
 });

--- a/app/frontend/src/playground/components/SessionSidebar.tsx
+++ b/app/frontend/src/playground/components/SessionSidebar.tsx
@@ -41,6 +41,7 @@ import { useTranslation } from 'react-i18next';
 import { LEFT_MENU_EXPANDED_WIDTH } from "../constants";
 import SessionRenameDialog from "./SessionRenameDialog";
 import { selectSessionsNewestFirst } from "../store/selectors/sessionSelectors";
+import { selectIsSessionWaitingById } from "../store/selectors/chatSelectors";
 import SyncStatusIndicator from "./SyncStatusIndicator";
 import ProfileMenu from "./ProfileMenu/ProfileMenu";
 import { deleteSession as deleteSessionThunk, persistSessionRename } from "../store/thunks/sessionManagementThunks";
@@ -62,6 +63,7 @@ const SessionSidebar: React.FC<SessionSidebarProps> = ({ isMobile }) => {
   const { t } = useTranslation('playground');
   const sessions = useAppSelector((state) => state.sessions.sessions);
   const sessionsNewestFirst = useAppSelector(selectSessionsNewestFirst);
+  const isSessionWaitingById = useAppSelector(selectIsSessionWaitingById);
   const currentSessionId = useAppSelector((state) => state.sessions.currentSessionId);
   const isSidebarCollapsed = useAppSelector(
     (state) => state.ui.isSidebarCollapsed
@@ -272,6 +274,8 @@ const SessionSidebar: React.FC<SessionSidebarProps> = ({ isMobile }) => {
   const chatItemRender = useCallback(({ index, style, ariaAttributes }: RowComponentProps) => {
     const session = sessionsNewestFirst[index];
     const isActiveOption = index === activeIndex;
+    const isWaitingForAssistant = Boolean(isSessionWaitingById[session.id]);
+    const waitingDescriptionId = `session-waiting-status-${session.id}`;
 
     return (
       <ListItem
@@ -319,14 +323,72 @@ const SessionSidebar: React.FC<SessionSidebarProps> = ({ isMobile }) => {
           onClick={() => activateSession(session.id)}
           aria-current={session.id === currentSessionId ? "page" : undefined}
           aria-selected={session.id === currentSessionId}
+          aria-describedby={isWaitingForAssistant ? waitingDescriptionId : undefined}
         >
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, width: "100%", minWidth: 0 }}>
             <Typography
+              data-testid={`session-title-${session.id}`}
+              data-waiting-for-response={isWaitingForAssistant ? "true" : "false"}
               noWrap
-              sx={{ flexGrow: 1, overflow: "hidden", textOverflow: "ellipsis" }}
+              sx={{
+                flexGrow: 1,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                fontWeight: isWaitingForAssistant ? 700 : 400,
+                transition: "font-weight 0.15s ease-in-out",
+              }}
             >
               {session.name}
             </Typography>
+            {isWaitingForAssistant && (
+              <Box
+                component="span"
+                id={waitingDescriptionId}
+                sx={{
+                  position: "absolute",
+                  width: 1,
+                  height: 1,
+                  p: 0,
+                  m: -1,
+                  overflow: "hidden",
+                  clip: "rect(0 0 0 0)",
+                  whiteSpace: "nowrap",
+                  border: 0,
+                }}
+              >
+                {t("sidebar.waitingForResponse")}
+              </Box>
+            )}
+            {isWaitingForAssistant && (
+              <Tooltip title={t("sidebar.waitingForResponse")} placement="top">
+                <Box
+                  component="span"
+                  aria-label={t("sidebar.waitingForResponse")}
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    minWidth: 8,
+                    minHeight: 8,
+                    flexShrink: 0,
+                    boxSizing: "border-box",
+                    borderRadius: "50%",
+                    backgroundColor: "info.main",
+                    display: "inline-block",
+                    boxShadow: "0 0 0 0 rgba(2, 136, 209, 0.7)",
+                    animation: "session-waiting-pulse 1.5s ease-in-out infinite",
+                    "@keyframes session-waiting-pulse": {
+                      "0%": { boxShadow: "0 0 0 0 rgba(2, 136, 209, 0.45)" },
+                      "70%": { boxShadow: "0 0 0 6px rgba(2, 136, 209, 0)" },
+                      "100%": { boxShadow: "0 0 0 0 rgba(2, 136, 209, 0)" },
+                    },
+                    "@media (prefers-reduced-motion: reduce)": {
+                      animation: "none",
+                      boxShadow: "none",
+                    },
+                  }}
+                />
+              </Tooltip>
+            )}
             <SyncStatusIndicator sessionId={session.id} variant="icon" />
           </Box>
         </ListItemButton>
@@ -361,7 +423,7 @@ const SessionSidebar: React.FC<SessionSidebarProps> = ({ isMobile }) => {
         </IconButton>
       </ListItem>
     );
-  }, [activeIndex, activateSession, currentSessionId, handleMoreMenuClick, moreMenuOpen, selectedSessionId, sessionsNewestFirst, t]);
+  }, [activeIndex, activateSession, currentSessionId, handleMoreMenuClick, isSessionWaitingById, moreMenuOpen, selectedSessionId, sessionsNewestFirst, t]);
 
   const sidebarContent = (
     <Box

--- a/app/frontend/src/playground/locales/translations.json
+++ b/app/frontend/src/playground/locales/translations.json
@@ -115,6 +115,10 @@
         "en": "Close chat sessions",
         "fr": "Fermer les sessions de conversation"
     },
+    "sidebar.waitingForResponse": {
+        "en": "Waiting for AI response",
+        "fr": "En attente d'une réponse de l'IA"
+    },
     "delete.conversation": {
         "en": "Delete Conversation",
         "fr": "Supprimer la conversation"

--- a/app/frontend/src/playground/store/persistence.test.ts
+++ b/app/frontend/src/playground/store/persistence.test.ts
@@ -33,6 +33,27 @@ describe("playground persistence migration", () => {
     expect(state.ui.isMobileSidebarOpen).toBe(false);
   });
 
+  it("resets persisted assistant response phases during hydration", () => {
+    localStorage.setItem(
+      "playground_chat_state",
+      JSON.stringify({
+        chat: {
+          messages: [],
+          assistantResponsePhaseBySessionId: {
+            s1: "streaming",
+            s2: "drafting",
+          },
+        },
+      })
+    );
+
+    const state = loadChatState() as {
+      chat: { assistantResponsePhaseBySessionId: Record<string, unknown> };
+    };
+
+    expect(state.chat.assistantResponsePhaseBySessionId).toEqual({});
+  });
+
   it("defaults ui state when missing in legacy payload", () => {
     localStorage.setItem(
       "playground_chat_state",
@@ -90,6 +111,19 @@ describe("playground persistence migration", () => {
         sessions: { sessions: [], currentSessionId: null },
         ui: { isSidebarCollapsed: true },
       });
+  });
+
+  it("does not persist assistant response phase", () => {
+    saveChatState({
+      chat: {
+        messages: [],
+        assistantResponsePhaseBySessionId: { s1: "streaming" },
+      },
+    });
+
+    const persisted = JSON.parse(localStorage.getItem("playground_chat_state") || "{}");
+
+    expect(persisted.chat).toEqual({ messages: [] });
   });
 
   it("detects when only transient slices changed so persistence can be skipped", () => {

--- a/app/frontend/src/playground/store/persistence.ts
+++ b/app/frontend/src/playground/store/persistence.ts
@@ -108,10 +108,8 @@ const migratePersistedState = (parsed: PersistedState): PersistedState => {
   next.chat = {
     messages: normalizePersistedMessages(chat.messages),
     isLoadingBySessionId: {},
-    assistantResponsePhaseBySessionId:
-      chat.assistantResponsePhaseBySessionId && typeof chat.assistantResponsePhaseBySessionId === "object"
-        ? chat.assistantResponsePhaseBySessionId
-        : {},
+    // Response phase is transient runtime state and must not survive reloads.
+    assistantResponsePhaseBySessionId: {},
     orchestratorInsightsBySessionId:
       chat.orchestratorInsightsBySessionId && typeof chat.orchestratorInsightsBySessionId === "object"
         ? chat.orchestratorInsightsBySessionId
@@ -146,13 +144,6 @@ export function createPersistableState(state: unknown): PersistedState {
       const nextChat: Record<string, unknown> = {
         messages: trimMessagesForPersistence(chat.messages),
       };
-
-      if (
-        chat.assistantResponsePhaseBySessionId
-        && typeof chat.assistantResponsePhaseBySessionId === "object"
-      ) {
-        nextChat.assistantResponsePhaseBySessionId = chat.assistantResponsePhaseBySessionId;
-      }
 
       if (
         chat.orchestratorInsightsBySessionId
@@ -190,7 +181,6 @@ const hasPersistedChatChanged = (
   const next = (nextChat as Record<string, unknown> | undefined) ?? {};
 
   return previous.messages !== next.messages
-    || previous.assistantResponsePhaseBySessionId !== next.assistantResponsePhaseBySessionId
     || previous.orchestratorInsightsBySessionId !== next.orchestratorInsightsBySessionId;
 };
 

--- a/app/frontend/src/playground/store/selectors/chatSelectors.test.ts
+++ b/app/frontend/src/playground/store/selectors/chatSelectors.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { RootState } from "../../store";
+import {
+  selectAssistantResponsePhaseForSession,
+  selectIsSessionWaitingForAssistant,
+  selectIsSessionWaitingById,
+} from "./chatSelectors";
+
+const makeState = (overrides?: {
+  isLoadingBySessionId?: Record<string, boolean>;
+  assistantResponsePhaseBySessionId?: Record<string, "idle" | "waiting-first-token" | "drafting" | "streaming" | undefined>;
+}) => ({
+  chat: {
+    messages: [],
+    isLoadingBySessionId: overrides?.isLoadingBySessionId ?? {},
+    assistantResponsePhaseBySessionId: overrides?.assistantResponsePhaseBySessionId ?? {},
+    orchestratorInsightsBySessionId: {},
+  },
+}) as RootState;
+
+describe("chatSelectors waiting state", () => {
+  it("returns idle phase when no session is provided", () => {
+    const state = makeState();
+
+    expect(selectAssistantResponsePhaseForSession(state, null)).toBe("idle");
+  });
+
+  it("returns false waiting state when no session is provided", () => {
+    const state = makeState();
+
+    expect(selectIsSessionWaitingForAssistant(state, null)).toBe(false);
+  });
+
+  it("marks waiting-first-token phase as waiting", () => {
+    const state = makeState({
+      assistantResponsePhaseBySessionId: { s1: "waiting-first-token" },
+    });
+
+    expect(selectAssistantResponsePhaseForSession(state, "s1")).toBe("waiting-first-token");
+    expect(selectIsSessionWaitingForAssistant(state, "s1")).toBe(true);
+  });
+
+  it("marks drafting and streaming phases as waiting", () => {
+    const draftingState = makeState({
+      assistantResponsePhaseBySessionId: { s1: "drafting" },
+    });
+    const streamingState = makeState({
+      assistantResponsePhaseBySessionId: { s1: "streaming" },
+    });
+
+    expect(selectIsSessionWaitingForAssistant(draftingState, "s1")).toBe(true);
+    expect(selectIsSessionWaitingForAssistant(streamingState, "s1")).toBe(true);
+  });
+
+  it("marks session loading as waiting even when phase is idle", () => {
+    const state = makeState({
+      isLoadingBySessionId: { s1: true },
+      assistantResponsePhaseBySessionId: { s1: "idle" },
+    });
+
+    expect(selectIsSessionWaitingForAssistant(state, "s1")).toBe(true);
+  });
+
+  it("returns false when loading is false and phase is idle", () => {
+    const state = makeState({
+      isLoadingBySessionId: { s1: false },
+      assistantResponsePhaseBySessionId: { s1: "idle" },
+    });
+
+    expect(selectAssistantResponsePhaseForSession(state, "s1")).toBe("idle");
+    expect(selectIsSessionWaitingForAssistant(state, "s1")).toBe(false);
+  });
+
+  it("builds waiting flags by session id", () => {
+    const state = makeState({
+      isLoadingBySessionId: { s1: true },
+      assistantResponsePhaseBySessionId: { s2: "streaming", s3: "idle" },
+    });
+
+    expect(selectIsSessionWaitingById(state)).toEqual({
+      s1: true,
+      s2: true,
+      s3: false,
+    });
+  });
+});

--- a/app/frontend/src/playground/store/selectors/chatSelectors.test.ts
+++ b/app/frontend/src/playground/store/selectors/chatSelectors.test.ts
@@ -9,14 +9,15 @@ import {
 const makeState = (overrides?: {
   isLoadingBySessionId?: Record<string, boolean>;
   assistantResponsePhaseBySessionId?: Record<string, "idle" | "waiting-first-token" | "drafting" | "streaming" | undefined>;
-}) => ({
-  chat: {
-    messages: [],
-    isLoadingBySessionId: overrides?.isLoadingBySessionId ?? {},
-    assistantResponsePhaseBySessionId: overrides?.assistantResponsePhaseBySessionId ?? {},
-    orchestratorInsightsBySessionId: {},
-  },
-}) as RootState;
+}): RootState =>
+  ({
+    chat: {
+      messages: [],
+      isLoadingBySessionId: overrides?.isLoadingBySessionId ?? {},
+      assistantResponsePhaseBySessionId: overrides?.assistantResponsePhaseBySessionId ?? {},
+      orchestratorInsightsBySessionId: {},
+    },
+  }) as unknown as RootState;
 
 describe("chatSelectors waiting state", () => {
   it("returns idle phase when no session is provided", () => {

--- a/app/frontend/src/playground/store/selectors/chatSelectors.ts
+++ b/app/frontend/src/playground/store/selectors/chatSelectors.ts
@@ -7,12 +7,20 @@
 
 import { createSelector } from "reselect";
 import { RootState } from "../../store";
-import type { Message } from "../slices/chatSlice";
+import type { AssistantResponsePhase, Message } from "../slices/chatSlice";
 
 // Input selectors
 const selectMessages = (state: RootState) => state.chat.messages;
 const selectCurrentSessionId = (state: RootState) =>
   state.sessions.currentSessionId;
+const selectSessionLoadingById = (state: RootState) => state.chat.isLoadingBySessionId;
+const selectAssistantResponsePhaseBySessionId = (state: RootState) => state.chat.assistantResponsePhaseBySessionId;
+
+const WAITING_ASSISTANT_PHASES: ReadonlySet<AssistantResponsePhase> = new Set([
+  "waiting-first-token",
+  "drafting",
+  "streaming",
+]);
 
 const EMPTY_MESSAGES: Message[] = [];
 const sessionMessagesCache = new WeakMap<Message[], Map<string, Message[]>>();
@@ -55,4 +63,55 @@ export const selectHasMessagesForSession = (
 export const selectMessagesBySessionId = createSelector(
   [selectMessages, selectCurrentSessionId],
   (messages, currentSessionId) => getCachedSessionMessages(messages, currentSessionId)
+);
+
+export const selectAssistantResponsePhaseForSession = (
+  state: RootState,
+  sessionId: string | null | undefined,
+): AssistantResponsePhase => {
+  if (!sessionId) {
+    return "idle";
+  }
+
+  return state.chat.assistantResponsePhaseBySessionId[sessionId] ?? "idle";
+};
+
+export const selectIsSessionWaitingForAssistant = createSelector(
+  [
+    selectSessionLoadingById,
+    selectAssistantResponsePhaseBySessionId,
+    (_: RootState, sessionId: string | null | undefined) => sessionId,
+  ],
+  (loadingBySessionId, phaseBySessionId, sessionId): boolean => {
+    if (!sessionId) {
+      return false;
+    }
+
+    if (Boolean(loadingBySessionId[sessionId])) {
+      return true;
+    }
+
+    const phase = phaseBySessionId[sessionId] ?? "idle";
+    return WAITING_ASSISTANT_PHASES.has(phase);
+  }
+);
+
+export const selectIsSessionWaitingById = createSelector(
+  [selectSessionLoadingById, selectAssistantResponsePhaseBySessionId],
+  (loadingBySessionId, phaseBySessionId): Record<string, boolean> => {
+    const sessionIds = new Set([
+      ...Object.keys(loadingBySessionId),
+      ...Object.keys(phaseBySessionId),
+    ]);
+
+    const waitingBySessionId: Record<string, boolean> = {};
+
+    sessionIds.forEach((sessionId) => {
+      const isLoading = Boolean(loadingBySessionId[sessionId]);
+      const phase = phaseBySessionId[sessionId] ?? "idle";
+      waitingBySessionId[sessionId] = isLoading || WAITING_ASSISTANT_PHASES.has(phase);
+    });
+
+    return waitingBySessionId;
+  }
 );


### PR DESCRIPTION
- Implement selectors for session waiting states in chatSelectors.
- Update SessionSidebar to reflect waiting states in the UI.
- Add translations for waiting response messages.
- Create tests for chat selectors to ensure correct waiting state logic.