### PR TITLE
fix: update heading components for improved accessibility in ChatArea…

### DIFF
--- a/app/frontend/src/playground/components/ChatArea.tsx
+++ b/app/frontend/src/playground/components/ChatArea.tsx
@@ -364,7 +364,9 @@ const ChatArea: React.FC<ChatAreaProps> = ({
           justifyContent="center"
           minWidth={0}
         >
-          {t("select.or.create.session")}
+          <Typography component="h1" variant="body1">
+            {t("select.or.create.session")}
+          </Typography>
         </Box>
       </Box>
     );

--- a/app/frontend/src/playground/components/ChatArea.tsx
+++ b/app/frontend/src/playground/components/ChatArea.tsx
@@ -418,7 +418,7 @@ const ChatArea: React.FC<ChatAreaProps> = ({
       >
         {renderHeader()}
         <Box flex={1} display="flex" flexDirection="column" alignItems="center" justifyContent="center" p={{ xs: 2, sm: 4, md: 6 }} minWidth={0}>
-          <Typography component="h2" variant="h3" gutterBottom>
+          <Typography component="h1" variant="h3" gutterBottom>
             {t("how.can.i.help")}
           </Typography>
           <Typography

--- a/app/frontend/src/playground/components/TopBar.tsx
+++ b/app/frontend/src/playground/components/TopBar.tsx
@@ -123,7 +123,7 @@ const TopBar: React.FC<TopBarProps> = ({
           />
           <Typography
             variant="h6"
-            component="h1"
+            component="span"
             sx={{
               fontSize: { xs: "16px", sm: "20px" },
               fontWeight: "500",


### PR DESCRIPTION
TopBar.tsx:127 — component="h1" → component="span"
The "SSC Assistant" text is branding chrome inside the <AppBar> (which already renders as a <header> landmark). Making it a heading was incorrect — it should be unsemantic inline text, not a document-structure heading.

ChatArea.tsx:444 — component="h2" → component="h1"
"How can I help?" is the first (and only) content-area heading on the welcome screen. With the branding demoted to <span>, this can correctly become the page's <h1>.