### PR TITLE
896 improve hover states for ssc assistant UI components

### DIFF
--- a/app/frontend/src/playground/components/ChatInput.tsx
+++ b/app/frontend/src/playground/components/ChatInput.tsx
@@ -427,14 +427,24 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
           onClick={isLoading ? onStop : handleSend}
           disabled={isUploading || (!isLoading && !canSend)}
           sx={{
-            '&:hover': { backgroundColor: 'rgba(0,0,0,0.08)' },
             minWidth: 44,
             minHeight: 44,
+            borderRadius: '50%',
+            transition: 'background-color 0.2s ease, color 0.2s ease, transform 0.2s ease',
+            color: canSend && !isLoading && !isUploading ? 'primary.main' : 'text.secondary',
+            '&:hover': canSend && !isLoading && !isUploading ? {
+              bgcolor: 'primary.main',
+              color: 'common.white',
+              transform: 'translateY(-1px)',
+            } : {
+              bgcolor: 'action.hover',
+              color: 'text.secondary',
+            },
             '&:focus-visible': {
               outline: `3px solid ${theme.palette.primary.main}`,
               outlineOffset: 3,
             },
-          }}
+          }} 
           aria-label={
             isLoading
               ? t('stop', { defaultValue: 'Stop' })
@@ -468,7 +478,12 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
               </Box>
             </Box>
           ) : (
-            <SendIcon sx={{ color: 'primary.main' }} aria-hidden="true" />
+            <SendIcon
+              sx={{
+                color: canSend && !isLoading && !isUploading ? 'inherit' : 'inherit',
+              }}
+              aria-hidden="true"
+            />
           )}
         </IconButton>
         {/*

--- a/app/frontend/src/playground/components/ChatInput.tsx
+++ b/app/frontend/src/playground/components/ChatInput.tsx
@@ -479,9 +479,6 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
             </Box>
           ) : (
             <SendIcon
-              sx={{
-                color: canSend && !isLoading && !isUploading ? 'inherit' : 'inherit',
-              }}
               aria-hidden="true"
             />
           )}

--- a/app/frontend/src/playground/components/FeedbackForm.tsx
+++ b/app/frontend/src/playground/components/FeedbackForm.tsx
@@ -110,14 +110,16 @@ const FeedbackForm: React.FC<FeedbackFormProps> = ({ placement = "floating" }) =
           fontWeight: "bold",
           borderRadius: "8px",
           fontSize: { xs: "0.75rem", sm: "0.875rem" },
+          border: "2px solid transparent",
+          boxSizing: "border-box",
           "& .MuiButton-startIcon": {
             marginLeft: placement === "topbar" ? { xs: 0, sm: -0.5 } : undefined,
             marginRight: placement === "topbar" ? { xs: 0, sm: 1 } : undefined,
           },
           "&:hover": {
-            bgcolor: placement === "topbar" ? "action.hover" : "primary.main",
-            color: "#f5f5f5",
-            border: "2px solid white",
+            bgcolor: placement === "topbar" ? "primary.dark" : "common.white",
+            color: placement === "topbar" ? "common.white" : "primary.main",
+            borderColor: placement === "topbar" ? "common.white" : "primary.main",
           },
         }}
       >

--- a/app/frontend/src/playground/components/FeedbackForm.tsx
+++ b/app/frontend/src/playground/components/FeedbackForm.tsx
@@ -116,7 +116,8 @@ const FeedbackForm: React.FC<FeedbackFormProps> = ({ placement = "floating" }) =
           },
           "&:hover": {
             bgcolor: placement === "topbar" ? "action.hover" : "primary.main",
-            color: placement === "topbar" ? "primary.dark" : "primary.contrastText",
+            color: "#f5f5f5",
+            border: "2px solid white",
           },
         }}
       >

--- a/app/frontend/src/playground/components/FileUpload.tsx
+++ b/app/frontend/src/playground/components/FileUpload.tsx
@@ -77,8 +77,20 @@ const FileUpload: React.FC<FileUploadProps> = ({ onFiles, disabled }) => {
               minHeight: 44,
               border: (theme) => `1px solid ${theme.palette.divider}`,
               bgcolor: (theme) => theme.palette.background.paper,
+              color: (theme) => theme.palette.text.primary,
+              transition: 'background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease',
               '&:hover': {
-                bgcolor: (theme) => theme.palette.action.hover,
+                bgcolor: (theme) => theme.palette.primary.main,
+                color: (theme) => theme.palette.common.white,
+              },
+              '&:focus-visible': {
+                outline: '2px solid',
+                outlineColor: (theme) => theme.palette.primary.main,
+                outlineOffset: 2,
+              },
+              '&:disabled': {
+                opacity: 0.6,
+                cursor: 'not-allowed',
               },
             }}
           >

--- a/app/frontend/src/playground/components/ProfileMenu/ProfileMenu.tsx
+++ b/app/frontend/src/playground/components/ProfileMenu/ProfileMenu.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { RootState } from '../../store';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from "react-redux";
+import { alpha } from "@mui/material";
 import {
   Box,
   Button,
@@ -91,14 +92,11 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
           textTransform: "none",
           transition: "background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease",
           '&:hover': {
-            backgroundColor: "rgba(25, 118, 210, 0.08)",
+            backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.08),
             borderColor: "primary.main",
           },
           '&:hover .MuiTypography-root': {
             borderColor: "primary.main",
-            paddingBottom: "2px",
-          },
-          '&:hover .MuiAvatar-root': {
           },
         }}
         onClick={handleOpen}

--- a/app/frontend/src/playground/components/ProfileMenu/ProfileMenu.tsx
+++ b/app/frontend/src/playground/components/ProfileMenu/ProfileMenu.tsx
@@ -79,7 +79,27 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
         id="profile-menu-button"
         sx={{
           cursor: "pointer",
-          width: 1
+          width: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-start",
+          px: 1,
+          py: 0.75,
+          borderRadius: 1,
+          border: "1px solid transparent",
+          color: "text.primary",
+          textTransform: "none",
+          transition: "background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease",
+          '&:hover': {
+            backgroundColor: "rgba(25, 118, 210, 0.08)",
+            borderColor: "primary.main",
+          },
+          '&:hover .MuiTypography-root': {
+            borderColor: "primary.main",
+            paddingBottom: "2px",
+          },
+          '&:hover .MuiAvatar-root': {
+          },
         }}
         onClick={handleOpen}
         tabIndex={0}
@@ -89,8 +109,8 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
         aria-controls={isOpen ? "profile-menu" : undefined}
         aria-expanded={isOpen ? "true" : "false"}
       >
-          <UserProfilePicture size={size} fontSize={fontSize} />
-          <Box //floats the avatar and name to left
+        <UserProfilePicture size={size} fontSize={fontSize} />
+        <Box //floats the avatar and name to left
             sx={{
               marginLeft: "auto",
               display: "flex",

--- a/app/frontend/src/playground/components/SessionSidebar.tsx
+++ b/app/frontend/src/playground/components/SessionSidebar.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useCallback, useState } from "react";
+import { alpha } from "@mui/material";
 import { List as ListWindow, RowComponentProps } from "react-window";
 import type { ListImperativeAPI } from "react-window";
 import useMeasure from "react-use-measure";
@@ -273,13 +274,13 @@ const SessionSidebar: React.FC<SessionSidebarProps> = ({ isMobile }) => {
           outline: isActiveOption ? "2px solid" : "2px solid transparent",
           outlineColor: isActiveOption ? "primary.main" : "transparent",
           outlineOffset: -2,
-          backgroundColor: session.id === currentSessionId ? "rgba(25, 118, 210, 0.08)" : "transparent",
+          backgroundColor: session.id === currentSessionId ? "action.selected" : "transparent",
           boxSizing: "border-box",
           width: "100%",
           border: "1px solid transparent",
           transition: "background-color 0.15s ease, border-color 0.15s ease",
           "&:hover": {
-            backgroundColor: "rgba(25, 118, 210, 0.08)",
+            backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.08),
             borderColor: "primary.light",
           },
           "& .more-button": {
@@ -457,8 +458,10 @@ const SessionSidebar: React.FC<SessionSidebarProps> = ({ isMobile }) => {
               py: 0.75,
               transition: "background-color 0.15s ease",
               boxSizing: 'border-box',
+              borderTop: "1px solid transparent",
+              borderBottom: "1px solid transparent",
               "&:hover": {
-                backgroundColor: "rgba(25, 118, 210, 0.08)",
+                backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.08),
                 borderTop: "1px solid",
                 borderBottom: "1px solid",
                 borderColor: "primary.light",

--- a/app/frontend/src/playground/components/SessionSidebar.tsx
+++ b/app/frontend/src/playground/components/SessionSidebar.tsx
@@ -273,12 +273,15 @@ const SessionSidebar: React.FC<SessionSidebarProps> = ({ isMobile }) => {
           outline: isActiveOption ? "2px solid" : "2px solid transparent",
           outlineColor: isActiveOption ? "primary.main" : "transparent",
           outlineOffset: -2,
-          backgroundColor:
-            session.id === currentSessionId ? "action.selected" : "transparent",
+          backgroundColor: session.id === currentSessionId ? "rgba(25, 118, 210, 0.08)" : "transparent",
+          boxSizing: "border-box",
+          width: "100%",
+          border: "1px solid transparent",
+          transition: "background-color 0.15s ease, border-color 0.15s ease",
           "&:hover": {
-            backgroundColor: "action.hover",
+            backgroundColor: "rgba(25, 118, 210, 0.08)",
+            borderColor: "primary.light",
           },
-          transition: "none",
           "& .more-button": {
             opacity: 1,
             color: "text.disabled",
@@ -445,7 +448,23 @@ const SessionSidebar: React.FC<SessionSidebarProps> = ({ isMobile }) => {
 
       <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1, minHeight: 0 }}>
         <Box key="newChat">
-          <ListItemButton id="new-chat-button" onClick={handleNewSession} aria-label={t("new.chat.aria")}>
+          <ListItemButton 
+            id="new-chat-button" 
+            onClick={handleNewSession} 
+            aria-label={t("new.chat.aria")}
+            sx={{
+              px: 1,
+              py: 0.75,
+              transition: "background-color 0.15s ease",
+              boxSizing: 'border-box',
+              "&:hover": {
+                backgroundColor: "rgba(25, 118, 210, 0.08)",
+                borderTop: "1px solid",
+                borderBottom: "1px solid",
+                borderColor: "primary.light",
+              },
+            }}
+          >
             <ListItemIcon sx={{ minWidth: "0px", mr: "10px" }}>
               <AddCommentIcon fontSize="small" color="primary" />
             </ListItemIcon>

--- a/app/frontend/src/playground/components/TopBar.tsx
+++ b/app/frontend/src/playground/components/TopBar.tsx
@@ -194,7 +194,8 @@ const TopBar: React.FC<TopBarProps> = ({
                   "&:focus-visible": { outline: "2px solid #fff", outlineOffset: "2px" },
                   "&:hover": {
                     border: "2px solid",
-                    borderColor: "common.white"
+                    borderColor: "common.white",
+                    bgcolor: "primary.dark",
                   },
                 }}
               >

--- a/app/frontend/src/playground/components/TopBar.tsx
+++ b/app/frontend/src/playground/components/TopBar.tsx
@@ -188,8 +188,12 @@ const TopBar: React.FC<TopBarProps> = ({
                   minHeight: 44,
                   opacity: Boolean(isExportDisabled || isExporting) ? 0.4 : 1,
                   pointerEvents: "auto",
+                  boxSizing: "border-box",
                   // WCAG 2.4.7 — white ring stays visible on the dark gradient toolbar.
                   "&:focus-visible": { outline: "2px solid #fff", outlineOffset: "2px" },
+                  "&:hover": {
+                    border: "2px solid white",
+                  },
                 }}
               >
                 <FileDownloadIcon />
@@ -243,8 +247,9 @@ const TopBar: React.FC<TopBarProps> = ({
                 display: "none"
               },
               "&:hover": {
-                bgcolor: "#f5f5f5",
-                color: "#2e3470",
+                bgcolor: "primary.dark",
+                color: "#f5f5f5",
+                border: "2px solid white",
               },
             }}
           >
@@ -265,6 +270,7 @@ const TopBar: React.FC<TopBarProps> = ({
               fontSize: { xs: "14px", sm: "16px" },
               "&:hover": {
                 bgcolor: "rgba(255, 255, 255, 0.1)",
+                border: "2px solid white",
               },
               // WCAG 2.4.7 — white ring stays visible on the dark gradient toolbar.
               "&:focus-visible": { outline: "2px solid #fff", outlineOffset: "2px" },

--- a/app/frontend/src/playground/components/TopBar.tsx
+++ b/app/frontend/src/playground/components/TopBar.tsx
@@ -273,6 +273,8 @@ const TopBar: React.FC<TopBarProps> = ({
               minHeight: "44px",
               fontWeight: "bold",
               fontSize: { xs: "14px", sm: "16px" },
+              boxSizing: "border-box",
+              border: "2px solid transparent",
               "&:hover": {
                 bgcolor: "primary.dark",
                 border: "2px solid white",

--- a/app/frontend/src/playground/components/TopBar.tsx
+++ b/app/frontend/src/playground/components/TopBar.tsx
@@ -189,10 +189,12 @@ const TopBar: React.FC<TopBarProps> = ({
                   opacity: Boolean(isExportDisabled || isExporting) ? 0.4 : 1,
                   pointerEvents: "auto",
                   boxSizing: "border-box",
+                  border: "2px solid transparent",
                   // WCAG 2.4.7 — white ring stays visible on the dark gradient toolbar.
                   "&:focus-visible": { outline: "2px solid #fff", outlineOffset: "2px" },
                   "&:hover": {
-                    border: "2px solid white",
+                    border: "2px solid",
+                    borderColor: "common.white"
                   },
                 }}
               >
@@ -235,6 +237,8 @@ const TopBar: React.FC<TopBarProps> = ({
               textTransform: "none",
               fontWeight: "bold",
               lineHeight: 1.2,
+              border: "2px solid transparent",
+              boxSizing: "border-box",
               borderRadius: "8px",
               padding: { xs: "4px 8px", sm: "6px 16px" },
               fontSize: { xs: "0.75rem", sm: "0.875rem" },
@@ -248,7 +252,7 @@ const TopBar: React.FC<TopBarProps> = ({
               },
               "&:hover": {
                 bgcolor: "primary.dark",
-                color: "#f5f5f5",
+                color: "common.white",
                 border: "2px solid white",
               },
             }}
@@ -269,7 +273,7 @@ const TopBar: React.FC<TopBarProps> = ({
               fontWeight: "bold",
               fontSize: { xs: "14px", sm: "16px" },
               "&:hover": {
-                bgcolor: "rgba(255, 255, 255, 0.1)",
+                bgcolor: "primary.dark",
                 border: "2px solid white",
               },
               // WCAG 2.4.7 — white ring stays visible on the dark gradient toolbar.

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -85,7 +85,7 @@ resource "azurerm_linux_web_app" "api" {
     api_definition_url = "https://${replace(var.project_name, "_", "-")}-api.azurewebsites.net/openapi.json"
 
     application_stack {
-      python_version = "3.12"
+      python_version = "3.13.14"
     }
     use_32_bit_worker = false
 


### PR DESCRIPTION
This PR updates the playground UI to make the chat composer controls feel more polished and consistent.

- Updated the hover states for sidebar chat items and the profile section to make hover state color consistent with the overall primary color scheme of SSCA. 
- Improved the attachment button hover state in the chat bar
- Updated the send button interaction states so it:
    - appears grey when inactive
    - switches to primary color when active
    - shows a refined hover state with white icon styling

- Updated the top bar button hover states for:
    -  download icon
    -  chat
    -  feedback
    -  language toggle
    
 

https://github.com/user-attachments/assets/51e6f81c-1355-4808-bc45-61d58b4028b8

