### PR TITLE
[902] Fixed missing translations for MCP/Orchestrator errors

### DIFF
--- a/app/frontend/src/playground/locales/translations.json
+++ b/app/frontend/src/playground/locales/translations.json
@@ -411,6 +411,10 @@
         "en": "Could not delete all chats. Please try again.",
         "fr": "Impossible de supprimer toutes les conversations. Veuillez réessayer."
     },
+    "errors.deleteAllPartial": {
+        "en": "Some conversations could not be deleted. Please refresh to see current state.",
+        "fr": "Certaines conversations n'ont pas pu être supprimées. Veuillez actualiser pour voir l'état actuel."
+    },
     "errors.mcpUnavailable": {
         "en": "MCP tools were unavailable for this response, so the assistant retried without tools. Citations may be missing.",
         "fr": "Les outils MCP n'étaient pas disponibles pour cette réponse, donc l'assistant a réessayé sans outils. Des citations peuvent être manquantes."
@@ -418,6 +422,10 @@
     "errors.orchestratorUnconfigured": {
         "en": "Orchestrator MCP is not configured; routing will fall back to available MCP servers.",
         "fr": "L'orchestrateur MCP n'est pas configuré ; le routage utilisera les serveurs MCP disponibles en remplacement."
+    },
+    "errors.renameFailed": {
+        "en": "Could not rename the chat. Please try again.",
+        "fr": "Impossible de renommer la conversation. Veuillez réessayer."
     },
     "errors.sessionFilesLoadFailed": {
         "en": "Could not load session files. Please refresh the page.",

--- a/app/frontend/src/playground/locales/translations.json
+++ b/app/frontend/src/playground/locales/translations.json
@@ -403,6 +403,14 @@
         "en": "Could not delete the chat. Please try again.",
         "fr": "Impossible de supprimer la conversation. Veuillez réessayer."
     },
+    "errors.mcpUnavailable": {
+        "en": "MPC tools were unavailable for this response, so the assistant retried without tools. Citations may be missing.",
+        "fr": "Les outils MPC n'étaient pas disponibles pour cette réponse, donc l'assistant a réessayé sans outils. Des citations peuvent être manquantes."
+    },
+    "errors.orchestratorUnconfigured": {
+        "en": "Orchestrator MCP is not configured; routing will fall back to available MCP servers.",
+        "fr": "L'orchestrateur MCP n'est pas configuré ; le routage utilisera les serveurs MCP disponibles en remplacement."
+    },
     "errors.sessionFilesLoadFailed": {
         "en": "Could not load session files. Please refresh the page.",
         "fr": "Impossible de charger les fichiers de session. Veuillez actualiser la page."

--- a/app/frontend/src/playground/locales/translations.json
+++ b/app/frontend/src/playground/locales/translations.json
@@ -111,6 +111,10 @@
         "en": "Delete",
         "fr": "Supprimer"
     },
+    "delete.all.success": {
+        "en": "All conversations deleted.",
+        "fr": "Toutes les conversations ont été supprimées."
+    },
     "delete.success": {
         "en": "Conversation deleted",
         "fr": "Conversation supprimée"
@@ -402,6 +406,10 @@
     "errors.deleteFailed": {
         "en": "Could not delete the chat. Please try again.",
         "fr": "Impossible de supprimer la conversation. Veuillez réessayer."
+    },
+    "errors.deleteAllFailed": {
+        "en": "Could not delete all chats. Please try again.",
+        "fr": "Impossible de supprimer toutes les conversations. Veuillez réessayer."
     },
     "errors.mcpUnavailable": {
         "en": "MCP tools were unavailable for this response, so the assistant retried without tools. Citations may be missing.",

--- a/app/frontend/src/playground/locales/translations.json
+++ b/app/frontend/src/playground/locales/translations.json
@@ -403,6 +403,10 @@
         "en": "Open source in a new tab: {{title}}",
         "fr": "Ouvrir la source dans un nouvel onglet : {{title}}"
     },
+    "errors.attachmentExtractionFailed": {
+        "en": "Could not read these files: {{files}}",
+        "fr": "Impossible de lire ces fichiers : {{files}}"
+    },
     "errors.deleteFailed": {
         "en": "Could not delete the chat. Please try again.",
         "fr": "Impossible de supprimer la conversation. Veuillez réessayer."

--- a/app/frontend/src/playground/locales/translations.json
+++ b/app/frontend/src/playground/locales/translations.json
@@ -404,8 +404,8 @@
         "fr": "Impossible de supprimer la conversation. Veuillez réessayer."
     },
     "errors.mcpUnavailable": {
-        "en": "MPC tools were unavailable for this response, so the assistant retried without tools. Citations may be missing.",
-        "fr": "Les outils MPC n'étaient pas disponibles pour cette réponse, donc l'assistant a réessayé sans outils. Des citations peuvent être manquantes."
+        "en": "MCP tools were unavailable for this response, so the assistant retried without tools. Citations may be missing.",
+        "fr": "Les outils MCP n'étaient pas disponibles pour cette réponse, donc l'assistant a réessayé sans outils. Des citations peuvent être manquantes."
     },
     "errors.orchestratorUnconfigured": {
         "en": "Orchestrator MCP is not configured; routing will fall back to available MCP servers.",

--- a/app/frontend/src/playground/locales/translations.json
+++ b/app/frontend/src/playground/locales/translations.json
@@ -269,11 +269,11 @@
     },
     "suggestions.general.hire": {
         "en": "Can you tell me how do I find information on how to hire a student?",
-        "fr": "Pouvez-vous me dire comment trouver des informations sur l'embauche d'un étudiant?"
+        "fr": "Pouvez-vous me dire comment trouver des informations sur l'embauche d'un étudiant ?"
     },
     "suggestions.business.find": {
         "en": "What kind of questions can I ask about Business Requests (BR)?",
-        "fr": "Quel genre de questions puis-je poser sur les demandes opérationnelles (DO)?"
+        "fr": "Quel genre de questions puis-je poser sur les demandes opérationnelles (DO) ?"
     },
     "suggestions.business.pspc": {
         "en": "Find all the BRs submited in the last 3 weeks that are from the client PSPC",

--- a/app/frontend/src/playground/store/thunks/assistantThunks.ts
+++ b/app/frontend/src/playground/store/thunks/assistantThunks.ts
@@ -655,7 +655,7 @@ export const sendAssistantMessage = ({
     if (!hasOrchestratorServer) {
       dispatch(
         addToast({
-          message: "Orchestrator MCP is not configured; routing will fall back to available MCP servers.",
+          message: i18n.t("playground:errors.orchestratorUnconfigured"),
           isError: false,
         })
       );
@@ -1313,7 +1313,7 @@ export const sendAssistantMessage = ({
 
       dispatch(
         addToast({
-          message: "MCP tools were unavailable for this response, so the assistant retried without tools. Citations may be missing.",
+          message: i18n.t("playground:errors.mcpUnavailable"),
           isError: false,
         })
       );

--- a/app/frontend/src/playground/store/thunks/sessionManagementThunks.ts
+++ b/app/frontend/src/playground/store/thunks/sessionManagementThunks.ts
@@ -187,7 +187,7 @@ export const deleteAllSessions = (): AppThunk<Promise<void>> => async (
       dispatch(
         addToast({
           message: i18n.t("playground:delete.all.success", {
-            defaultValue: "All conversations deleted",
+            defaultValue: "All conversations deleted.",
           }),
           isError: false,
         })


### PR DESCRIPTION
This fix adds translations for "MCP tools were unavailable..." and "Orchestrator MCP is not configured" errors. 

CANChat was used for English-to-French translations.

Edit: Fixed or added 7 other translations.