### PR TITLE
Bug: Critical issues in Accessibility Review

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/app/frontend/playground.e2e.html
+++ b/app/frontend/playground.e2e.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/playground/e2e.tsx"></script>
   </body>
 </html>

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -19,7 +19,6 @@ interface AppProps {
 
 export const App = ({ instance }: AppProps) => {
   const { t } = useTranslation();
-  // Move scroll-lock from <body> to the child `#app-content` wrapper.
   // This watches for body.style changes (set by MUI) and applies overflow/padding to the wrapper instead.
   React.useEffect(() => {
     if (typeof document === 'undefined') return;

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { PublicClientApplication } from "@azure/msal-browser";
+import React from "react";
 import {
   AuthenticatedTemplate,
   UnauthenticatedTemplate,
@@ -18,13 +19,47 @@ interface AppProps {
 
 export const App = ({ instance }: AppProps) => {
   const { t } = useTranslation();
+  // Move scroll-lock from <body> to the child `#app-content` wrapper.
+  // This watches for body.style changes (set by MUI) and applies overflow/padding to the wrapper instead.
+  React.useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const body = document.body;
+    const appContent = document.getElementById('app-content');
+    if (!appContent) return;
+
+    const applyFromBody = () => {
+      const overflow = body.style.overflow;
+      const paddingRight = body.style.paddingRight;
+      if (overflow === 'hidden') {
+        if (!appContent.classList.contains('app-scroll-locked')) {
+          appContent.classList.add('app-scroll-locked');
+          if (paddingRight) appContent.style.paddingRight = paddingRight;
+          body.style.overflow = '';
+          body.style.paddingRight = '';
+        }
+      } else {
+        if (appContent.classList.contains('app-scroll-locked')) {
+          appContent.classList.remove('app-scroll-locked');
+          appContent.style.paddingRight = '';
+        }
+      }
+    };
+
+    // initial sync
+    applyFromBody();
+
+    const mo = new MutationObserver(() => applyFromBody());
+    mo.observe(body, { attributes: true, attributeFilter: ['style'] });
+    return () => mo.disconnect();
+  }, []);
+
   return (
     <>
       {/* Skip link for keyboard users to jump to the chat ask input.
           On the playground page, #playground-ask-question is used; elsewhere #ask-question. */}
       <a
         className="skip-link"
-        href="#ask-question"
+        href="#playground-ask-question"
         onClick={(e) => {
           const target =
             document.getElementById("playground-ask-question") ??
@@ -37,16 +72,18 @@ export const App = ({ instance }: AppProps) => {
       >{t("skip.to.chat.input")}</a>
       <MSClarity />
       <CssBaseline />
-      <AppErrorBoundary>
-        <MsalProvider instance={instance}>
-          <UnauthenticatedTemplate>
-            <ConnectingScreen />
-          </UnauthenticatedTemplate>
-          <AuthenticatedTemplate>
-            <AppRoutes />
-          </AuthenticatedTemplate>
-        </MsalProvider>
-      </AppErrorBoundary>
+      <div id="app-content">
+        <AppErrorBoundary>
+          <MsalProvider instance={instance}>
+            <UnauthenticatedTemplate>
+              <ConnectingScreen />
+            </UnauthenticatedTemplate>
+            <AuthenticatedTemplate>
+              <AppRoutes />
+            </AuthenticatedTemplate>
+          </MsalProvider>
+        </AppErrorBoundary>
+      </div>
       <AppSnackbars />
     </>
   );

--- a/app/frontend/src/components/AppSnackbar.tsx
+++ b/app/frontend/src/components/AppSnackbar.tsx
@@ -19,6 +19,13 @@ export const AppSnackbars = () => {
                         open={datum.isOpen}
                         message={datum.message}
                         TransitionComponent={SlideTransition}
+                        anchorOrigin={{
+                            vertical: "bottom",
+                            horizontal: "center",
+                        }}
+                        sx={{
+                            bottom: "var(--chat-input-height, 100px) !important",
+                        }}
                         style={{
                             maxWidth: "50%",
                         }}

--- a/app/frontend/src/components/AppSnackbar.tsx
+++ b/app/frontend/src/components/AppSnackbar.tsx
@@ -24,7 +24,10 @@ export const AppSnackbars = () => {
                             horizontal: "center",
                         }}
                         sx={{
-                            bottom: "var(--chat-input-height, 100px) !important",
+                        bottom: {
+                            xs: "calc(var(--chat-input-height, 100px) + env(safe-area-inset-bottom)) !important",
+                            sm: "24px !important",
+                        },
                         }}
                         style={{
                             maxWidth: "50%",

--- a/app/frontend/src/components/Disclaimer.tsx
+++ b/app/frontend/src/components/Disclaimer.tsx
@@ -6,6 +6,7 @@ import {
   DialogActions,
   Button,
 } from "@mui/material";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import { useMsal } from "@azure/msal-react";
@@ -65,6 +66,34 @@ export const Disclaimer = () => {
 
   const shouldShow = !!currentDisclaimerKey && inProgress === InteractionStatus.None;
 
+  // When the disclaimer dialog is visible, mark the application root as inert
+  // so that assistive technology and focus are not blocked by aria-hidden on ancestors.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.getElementById('root');
+    const modalRoot = document.getElementById('modal-root');
+    if (!root) return;
+    if (shouldShow) {
+      try {
+        (root as any).inert = true;
+      } catch (e) {
+        // inert might not be supported; best-effort only
+      }
+      if (modalRoot) {
+        modalRoot.removeAttribute('aria-hidden');
+      }
+    } else {
+      try {
+        (root as any).inert = false;
+      } catch (e) {}
+    }
+    return () => {
+      try {
+        (root as any).inert = false;
+      } catch (e) {}
+    };
+  }, [shouldShow]);
+
   const handleAccept = (key: DisclaimerKey) => {
     PersistenceUtils.setDisclaimerAccepted(key);
     setDisclaimerAcceptedState((prevState) => ({
@@ -79,39 +108,44 @@ export const Disclaimer = () => {
     return null; // No configuration found for the current disclaimer
   }
 
-  return (
-    <div>
-      <Dialog open={shouldShow} fullWidth>
-        <DialogTitle>
-          {currentDisclaimerConfig?.title
-            ? t("disclaimer") + " - " + t(currentDisclaimerConfig.title)
-            : t("disclaimer")}
-        </DialogTitle>
-        <DialogContent>
-          {currentDisclaimerConfig?.text && <p>{t(currentDisclaimerConfig.text)}</p>}
-          {currentDisclaimerConfig?.text2 && (
-            <p style={{ fontWeight: "bold" }}>{t(currentDisclaimerConfig.text2)}</p>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button
-            id="accept-disclaimer-button"
-            color='primary'
-            variant='contained'
-            onClick={() => handleAccept(currentDisclaimerConfig.key)}
-          >
-            {t("accept")}
-          </Button>
-          <Button
-            id="change-language-button"
-            onClick={() => {
-              appStore.languageService.changeLanguage();
-            }}
-          >
-            {t("langlink")}
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </div>
+  const dialog = (
+    <Dialog open={shouldShow} fullWidth disableScrollLock disablePortal>
+      <DialogTitle>
+        {currentDisclaimerConfig?.title
+          ? t("disclaimer") + " - " + t(currentDisclaimerConfig.title)
+          : t("disclaimer")}
+      </DialogTitle>
+      <DialogContent>
+        {currentDisclaimerConfig?.text && <p>{t(currentDisclaimerConfig.text)}</p>}
+        {currentDisclaimerConfig?.text2 && (
+          <p style={{ fontWeight: "bold" }}>{t(currentDisclaimerConfig.text2)}</p>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button
+          id="accept-disclaimer-button"
+          color='primary'
+          variant='contained'
+          onClick={() => handleAccept(currentDisclaimerConfig.key)}
+        >
+          {t("accept")}
+        </Button>
+        <Button
+          id="change-language-button"
+          onClick={() => {
+            appStore.languageService.changeLanguage();
+          }}
+        >
+          {t("langlink")}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
+
+  if (typeof document !== "undefined") {
+    const modalRoot = document.getElementById("modal-root");
+    if (modalRoot) return createPortal(dialog, modalRoot);
+  }
+
+  return dialog;
 };

--- a/app/frontend/src/components/TopMenu/subcomponents/TopMenuFrame.tsx
+++ b/app/frontend/src/components/TopMenu/subcomponents/TopMenuFrame.tsx
@@ -37,6 +37,8 @@ export const TopMenuFrame: FC<TopMenuProps> = ({
           top: 0,
           right: 0,
           width: `calc(100vw - ${isOpen ? LEFT_MENU_WIDTH : 0}px)`,
+          overflowX: "auto",
+          WebkitOverflowScrolling: "touch",
         }}
       >
         <Toolbar
@@ -49,10 +51,13 @@ export const TopMenuFrame: FC<TopMenuProps> = ({
             alignItems: "center",
             justifyContent: "space-between",
             flexShrink: 0,
+            flexWrap: "nowrap",
             borderRadius: 0,
             background: `linear-gradient(45deg, #222, ${theme.palette.primary.main})`,
             maxHeight: 40,
             border: "none",
+            overflowX: "auto",
+            overflowY: "hidden",
           })}
         >
           {childrenLeftOfLogo}
@@ -62,6 +67,8 @@ export const TopMenuFrame: FC<TopMenuProps> = ({
               alignItems: "center",
               gap: "1rem",
               userSelect: "none",
+              minWidth: 0,
+              whiteSpace: "nowrap",
             }}
           >
             <img
@@ -87,6 +94,9 @@ export const TopMenuFrame: FC<TopMenuProps> = ({
               gap: "1rem",
               justifyContent: "space-between",
               flexGrow: 1,
+              minWidth: 0,
+              overflowX: "auto",
+              whiteSpace: "nowrap",
             }}
           >
             {/* This is where the content will go. */}

--- a/app/frontend/src/index.css
+++ b/app/frontend/src/index.css
@@ -21,3 +21,14 @@
 	z-index: 10000;
 	text-decoration: none;
 }
+
+/* App content wrapper to allow scroll-lock to be applied to a child instead of the body */
+#app-content {
+  height: 100vh;
+  overflow: auto;
+}
+
+/* When scroll-locked, hide overflow on the wrapper and preserve layout */
+.app-scroll-locked {
+  overflow: hidden !important;
+}

--- a/app/frontend/src/playground/components/ChatArea.tsx
+++ b/app/frontend/src/playground/components/ChatArea.tsx
@@ -258,7 +258,7 @@ const ChatArea: React.FC<ChatAreaProps> = ({
   if (messages.length === 0) {
     return (
       <Box
-        component="main"
+        flex={1}
         display="flex"
         flexDirection="column"
         height="100dvh"

--- a/app/frontend/src/playground/components/ChatArea.tsx
+++ b/app/frontend/src/playground/components/ChatArea.tsx
@@ -258,6 +258,7 @@ const ChatArea: React.FC<ChatAreaProps> = ({
   if (messages.length === 0) {
     return (
       <Box
+        component="main"
         flex={1}
         display="flex"
         flexDirection="column"

--- a/app/frontend/src/playground/components/ChatArea.tsx
+++ b/app/frontend/src/playground/components/ChatArea.tsx
@@ -259,14 +259,13 @@ const ChatArea: React.FC<ChatAreaProps> = ({
     return (
       <Box
         component="main"
-        flex={1}
         display="flex"
         flexDirection="column"
         height="100dvh"
         minWidth={0}
       >
         {renderHeader()}
-        <Box flex={1} display="flex" flexDirection="column" alignItems="center" justifyContent="center" p={{ xs: 2, sm: 4, md: 6 }} minWidth={0}>
+        <Box display="flex" flexDirection="column" flex={1} minHeight={0} minWidth={0} alignItems="center" justifyContent="center" p={{ xs: 2, sm: 4, md: 6 }} overflow="auto">
           <Typography component="h1" variant="h3" gutterBottom>
             {t("how.can.i.help")}
           </Typography>

--- a/app/frontend/src/playground/components/ChatInput.tsx
+++ b/app/frontend/src/playground/components/ChatInput.tsx
@@ -9,7 +9,7 @@
  * - Accessible controls and keyboard behavior (Enter to send, Shift+Enter newline)
  */
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   Box,
   Paper,
@@ -79,7 +79,7 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
   const dispatch = useAppDispatch();
   const quotedText = useAppSelector((state: RootState) => state.quoted.quotedText);
   const isLoading = useAppSelector((state: RootState) => state.chat.isLoadingBySessionId[sessionId] ?? false);
-
+  const footerRef = useRef<HTMLDivElement>(null);
   // File attachment state managed by dedicated hook
   const {
     attachments,
@@ -116,7 +116,38 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
     }
   }, [quotedText]);
 
+  useLayoutEffect(() => {
+    const footer = footerRef.current;
 
+    if (!footer) return;
+
+    const updateHeight = () => {
+      const height = footer.getBoundingClientRect().height;
+
+      document.documentElement.style.setProperty(
+        "--chat-input-height",
+        `${height + 16}px`
+      );
+    };
+
+    updateHeight();
+
+    const observer = new ResizeObserver(() => {
+      updateHeight();
+    });
+
+    observer.observe(footer);
+
+    return () => {
+      observer.disconnect();
+
+      document.documentElement.style.removeProperty(
+        "--chat-input-height"
+      );
+    };
+  }, []);
+
+  
   /**
    * Submits the current message to the chat store including any quoted text and
    * attachments, then resets the composer state. Guarded against empty input
@@ -273,6 +304,7 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
 
   return (
     <Box
+      ref={footerRef}
       component="footer"
       sx={{
         position: "sticky",

--- a/app/frontend/src/playground/components/ChatInput.tsx
+++ b/app/frontend/src/playground/components/ChatInput.tsx
@@ -274,18 +274,23 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
   return (
     <Box
       component="footer"
-      maxWidth="md"
       sx={{
         position: "sticky",
         bottom: 0,
         boxShadow: `0px -15px 20px ${theme.palette.background.default}`,
-        pt: 1,
+        pt: 0.5,
         pb: 'env(safe-area-inset-bottom)',
         width: "100%",
-        mx: "auto",
+        maxWidth: "100%",
+        maxHeight: 130,
+        overflow: 'hidden',
+        px: { xs: 0.5, sm: 1 },
+        boxSizing: "border-box",
+        mx: 0,
         display: "flex",
         flexDirection: "column",
         alignItems: "stretch",
+        gap: 0.2,
       }}
     >
       {/* Quoted text banner */}
@@ -364,17 +369,19 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
         component="form"
         onSubmit={(e) => { e.preventDefault(); handleSend(); }}
         sx={{
-          p: "2px 5px",
+          p: "0.25rem 0.75rem",
           minWidth: 0,
           display: "flex",
           alignItems: "center",
-          borderRadius: attachments.length > 0 || quotedText ? "0 0 30px 30px" : "40px",
+          borderRadius: attachments.length > 0 || quotedText ? "0 0 28px 28px" : "32px",
           borderColor: dragActive ? theme.palette.secondary.main : theme.palette.primary.main,
           borderWidth: attachments.length > 0 || quotedText ? "0 1px 1px 1px" : "1px",
           borderStyle: "solid",
           background: dragActive ? theme.palette.action.hover : undefined,
           transition: "background 0.2s, border-color 0.2s",
-          minHeight: 60,
+          minHeight: 40,
+          maxHeight: 78,
+          overflow: 'hidden',
         }}
         aria-describedby={error ? 'chatinput-error' : undefined}
       >
@@ -403,7 +410,7 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
 
         <InputBase
           inputRef={inputRef}
-          sx={{ ml: 1, flex: 1, minWidth: 0 }}
+          sx={{ ml: 1, flex: 1, minWidth: 0, maxHeight: 64, overflowY: 'auto', lineHeight: 1.2, fontSize: '0.86rem', py: 0.3 }}
           // The visually-hidden <label htmlFor="playground-ask-question"> above
           // provides a label association. Add a persistent aria-label for
           // assistive tech and to satisfy the accessible name requirements.
@@ -413,7 +420,8 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
           }}
           value={input}
           multiline
-          maxRows={15}
+          minRows={1}
+          maxRows={3}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             const v = e.target.value;
             // Simple length validation with i18n fallback
@@ -431,8 +439,8 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
           onClick={isLoading ? onStop : handleSend}
           disabled={isUploading || (!isLoading && !canSend)}
           sx={{
-            minWidth: 44,
-            minHeight: 44,
+            minWidth: 38,
+            minHeight: 38,
             borderRadius: '50%',
             transition: 'background-color 0.2s ease, color 0.2s ease, transform 0.2s ease',
             color: canSend && !isLoading && !isUploading ? 'primary.main' : 'text.secondary',
@@ -552,9 +560,22 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
       )}
 
       {/* Footer helper text */}
-      <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', gap: 1, alignItems: 'center', py: 1 }}>
-        <InfoIcon fontSize="inherit" color="info" />
-        <Typography variant="body2" color="text.secondary">
+      <Box
+        sx={{
+          width: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          gap: 0.4,
+          alignItems: 'center',
+          py: 0.25,
+          px: 0.5,
+          minHeight: 22,
+          maxHeight: 22,
+          overflow: 'hidden',
+        }}
+      >
+        <InfoIcon fontSize="small" color="info" sx={{ transform: 'scale(0.85)' }} />
+        <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.1, fontSize: '0.72rem' }}>
           {t('ai.disclaimer', { defaultValue: 'AI may make mistakes' })}
         </Typography>
       </Box>

--- a/app/frontend/src/playground/components/ChatInput.tsx
+++ b/app/frontend/src/playground/components/ChatInput.tsx
@@ -405,8 +405,12 @@ const ChatInput: React.FC<ChatInputProps> = ({ sessionId }) => {
           inputRef={inputRef}
           sx={{ ml: 1, flex: 1, minWidth: 0 }}
           // The visually-hidden <label htmlFor="playground-ask-question"> above
-          // provides the accessible name, so no aria-label is needed here.
-          inputProps={{ tabIndex: 0 }}
+          // provides a label association. Add a persistent aria-label for
+          // assistive tech and to satisfy the accessible name requirements.
+          inputProps={{
+            tabIndex: 0,
+            'aria-label': t('type.a.message', { defaultValue: 'Your message' }),
+          }}
           value={input}
           multiline
           maxRows={15}

--- a/app/frontend/src/playground/components/PlaygroundDisclaimerDialog.tsx
+++ b/app/frontend/src/playground/components/PlaygroundDisclaimerDialog.tsx
@@ -10,6 +10,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
+import { createPortal } from "react-dom";
 
 import {
   acceptPlaygroundDisclaimer,
@@ -49,6 +50,29 @@ const PlaygroundDisclaimerDialog: React.FC = () => {
     [state],
   );
 
+  // Toggle `inert` on the application root while the playground disclaimer is visible
+  React.useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.getElementById('root');
+    const modalRoot = document.getElementById('modal-root');
+    if (!root) return;
+    if (currentDisclaimer) {
+      try {
+        (root as any).inert = true;
+      } catch (e) {}
+      if (modalRoot) modalRoot.removeAttribute('aria-hidden');
+    } else {
+      try {
+        (root as any).inert = false;
+      } catch (e) {}
+    }
+    return () => {
+      try {
+        (root as any).inert = false;
+      } catch (e) {}
+    };
+  }, [currentDisclaimer]);
+
   const handleAccept = () => {
     if (!currentDisclaimer) {
       return;
@@ -78,13 +102,15 @@ const PlaygroundDisclaimerDialog: React.FC = () => {
   const contentKeys = CONTENT_KEYS[currentDisclaimer];
   const descriptionId = "playground-disclaimer-description";
 
-  return (
+  const dialog = (
     <Dialog
       open
       fullWidth
       maxWidth="md"
       fullScreen={isSmallScreen}
       disableEscapeKeyDown
+      disableScrollLock
+      disablePortal
       onClose={handleMandatoryDialogClose}
       aria-labelledby="playground-disclaimer-title"
       aria-describedby={descriptionId}
@@ -127,6 +153,15 @@ const PlaygroundDisclaimerDialog: React.FC = () => {
       </DialogActions>
     </Dialog>
   );
+
+  if (typeof document !== "undefined") {
+    const modalRoot = document.getElementById("modal-root");
+    if (modalRoot) {
+      return createPortal(dialog, modalRoot);
+    }
+  }
+
+  return dialog;
 };
 
 export default PlaygroundDisclaimerDialog;

--- a/app/frontend/src/playground/components/PlaygroundRoot.tsx
+++ b/app/frontend/src/playground/components/PlaygroundRoot.tsx
@@ -64,10 +64,11 @@ export const PlaygroundShell: React.FC = () => {
 
   return (
     <Box display="flex" height="100dvh">
-      {/* WCAG 2.4.1 — skip link lets keyboard users bypass sidebar navigation */}
+      {/* WCAG 2.4.1 — skip link lets keyboard users bypass sidebar navigation
+          Target the chat input so users land directly in the composer. */}
       <Box
         component="a"
-        href="#playground-main-content"
+        href="#playground-ask-question"
         sx={{
           position: "absolute",
           left: "-999px",
@@ -96,11 +97,10 @@ export const PlaygroundShell: React.FC = () => {
       <SessionBootstrapper />
       <NewConversationOnOpen />
       <SessionSidebar isMobile={isMobile} />
-      {/* Skip-link target — ChatArea renders its own <main> landmark internally;
-          this div only needs tabIndex={-1} so the skip link can shift focus here
-          without adding a second <main> to the page. */}
+      {/* Container for the chat area. ChatArea renders a proper <main> landmark
+          internally; this wrapper keeps layout flex behavior and a focus target
+          for other flows. */}
       <Box
-        id="playground-main-content"
         tabIndex={-1}
         sx={{ flex: 1, display: "flex", minWidth: 0 }}
       >

--- a/app/frontend/src/playground/components/PlaygroundRoot.tsx
+++ b/app/frontend/src/playground/components/PlaygroundRoot.tsx
@@ -64,8 +64,7 @@ export const PlaygroundShell: React.FC = () => {
 
   return (
     <Box display="flex" height="100dvh">
-      {/* WCAG 2.4.1 — skip link lets keyboard users bypass sidebar navigation
-          Target the chat input so users land directly in the composer. */}
+      {/* WCAG 2.4.1 — skip link lets keyboard users bypass sidebar navigation */}
       <Box
         component="a"
         href="#playground-ask-question"

--- a/app/frontend/src/playground/components/ToastContainer.tsx
+++ b/app/frontend/src/playground/components/ToastContainer.tsx
@@ -43,6 +43,12 @@ const ToastContainer: React.FC = () => {
           autoHideDuration={getAutoHideDuration(toast)}
           onClose={() => dispatch(removeToast(toast.id))}
           anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+          sx={{
+            bottom: {
+              xs: "calc(var(--chat-input-height, 100px) + env(safe-area-inset-bottom)) !important",
+              sm: "24px !important",
+            },
+          }}
         >
           <Alert
             onClose={() => dispatch(removeToast(toast.id))}

--- a/app/frontend/tests/e2e/playground-accessibility.spec.ts
+++ b/app/frontend/tests/e2e/playground-accessibility.spec.ts
@@ -135,11 +135,11 @@ test('skip link focuses main content', async ({ playground }, testInfo) => {
   // The skip link should be the first focusable element.
   await playground.page.keyboard.press('Tab');
   const focused = playground.page.locator(':focus');
-  await expect(focused).toHaveAttribute('href', '#playground-main-content');
+  await expect(focused).toHaveAttribute('href', '#playground-ask-question');
 
-  // Activating it should move focus to the main content container.
+  // Activating it should move focus to the chat composer input.
   await playground.page.keyboard.press('Enter');
-  await expect(playground.page.locator('#playground-main-content')).toBeFocused();
+  await expect(playground.page.locator('#playground-ask-question')).toBeFocused();
 });
 
 /**


### PR DESCRIPTION
This PR attempts to fix all CRITICAL issues mentioned in the [Accessibility Report](https://github.com/dto-btn/ssc-assistant/issues/914)

### Changes

- C1 (`#root` aria-hidden blocking AT): fixed by rendering dialogs outside `#root` (portals to `#modal-root`) and applying `inert` to `#root` while dialogs are open so focusable elements aren’t hidden from AT. Also removed static `aria-hidden` from `#modal-root`.
- C2 (broken skip link): fixed by updating skip link target to `#playground-ask-question`.  
- C3 (skip lands in wrapper): fixed by pointing skip to the actionable input (chat textarea) so keyboard/screen-reader users land at the input.  
- C4 (body overflow:hidden scroll-lock): mitigated by moving scroll-lock from the <body> to the #app-content wrapper, allowing modals to lock scrolling without modifying the document body.
- C5 (textarea accessible name): fixed by adding a persistent `aria-label` to the chat input. 



### Testing

#### C1
1. Open up app, view disclaimer on startup.
2. In DevTools: Ctrl+F **#root** in Elements. Verify that `<div role="presentation">` is not under #root, but root's sibling #modal-root. See screenshot below for example.
3. Turn on Narrator and press Tab, making sure that all of the Disclaimer text is reachable by the Narrator. The following html should be visible in Elements while the disclaimer is visible.
<img width="529" height="192" alt="image" src="https://github.com/user-attachments/assets/b67657f2-65ae-491a-9831-790112185764" />

#### C2, C3
1. Load up main screen on playground (or F5 refresh)
2. Press Tab once --> Should see **Skip to chat input**
3. Press Tab twice --> Should see **Skip to main content**
5. Press Enter on either option --> Takes user to chat input
6. Verify (in code) that hrefs point to #playground-ask-question.

#### C4
Verify that all clipped content can be scrolled at 400% Zoom (Chat history, side bar, nav bar). Verify that scroll lock is in child wrapper, not <body>.

#### C5
Verify (in code) that chat input default "Your Message" is in correct place
