### PR TITLE
Add python-version input to API workflow and update Python version in…

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -13,6 +13,10 @@ on:
         type: string
         required: false
         default: 'ubuntu-latest'
+      python-version:
+        type: string
+        required: false
+        default: '3.13.14'
     secrets:
       API_PUBLISH_PROFILE:
         required: false
@@ -46,7 +50,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5.2.0
       with:
-        python-version: '3.13.14'
+        python-version: ${{ inputs.python-version }}
 
     # commenting this one out until we re-enable the MS SQL dependencies in the requirements.txt
     # - name: Install system dependencies

--- a/.github/workflows/assisstant.yml
+++ b/.github/workflows/assisstant.yml
@@ -60,6 +60,7 @@ jobs:
       environment: 'prod'
       app-name: 'G3Pc-SSC-CIOAssistant-Linux-API-asv'
       runner: 'self-hosted'
+      python-version: '3.12.13'
     secrets: inherit
 
   frontend-prod-163ent:


### PR DESCRIPTION
Why is prod set to 3.12.13 when the other are 3.13.14

3:59 PM
Because the production log shows that the actual Azure App Service runtime is Python 3.12.13:

Meanwhile, the workflow was building antenv with Python 3.13.14. Dependencies were installed under:

Production looked under python3.12, could not find [apiflask](vscode-file://vscode-app/c:/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and failed.

The production override in [assisstant.yml:63](vscode-file://vscode-app/c:/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) makes the deployment artifact match the current production runtime. Dev and pilot remain at 3.13.14 because this error only proves that enterprise production is still running 3.12.13.

This is a compatibility fix, not the ideal permanent configuration. The cleaner long-term solution is to upgrade the production App Service runtime to Python 3.13, verify Azure reports /opt/python/3.13..., and then remove the production override so every environment uses 3.13.14. Merely changing the workflow to 3.13 does not upgrade the App Service runtime.