### PR TITLE
Update LiteLLM configuration: Implemented the Easy Auth migration.

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -56,7 +56,7 @@ on:
         required: false
       VITE_PLAYGROUND_LITELLM_BASE_URL:
         required: false
-      VITE_PLAYGROUND_LITELLM_PROXY_KEY:
+      VITE_PLAYGROUND_LITELLM_SCOPE:
         required: false
 
 permissions:
@@ -107,7 +107,7 @@ jobs:
         VITE_PLAYGROUND_SHOW_ORCHESTRATOR_DEBUG: ${{ inputs.enable-playground && secrets.VITE_PLAYGROUND_SHOW_ORCHESTRATOR_DEBUG || '' }}
         VITE_PLAYGROUND_USE_LITELLM: ${{ inputs.enable-playground && secrets.VITE_PLAYGROUND_USE_LITELLM || '' }}
         VITE_PLAYGROUND_LITELLM_BASE_URL: ${{ inputs.enable-playground && secrets.VITE_PLAYGROUND_LITELLM_BASE_URL || '' }}
-        VITE_PLAYGROUND_LITELLM_PROXY_KEY: ${{ inputs.enable-playground && secrets.VITE_PLAYGROUND_LITELLM_PROXY_KEY || '' }}
+        VITE_PLAYGROUND_LITELLM_SCOPE: ${{ inputs.enable-playground && secrets.VITE_PLAYGROUND_LITELLM_SCOPE || '' }}
     # This step will only run when the event is a push to the main branch
     - name: Zip artifact for deployment
       if: github.event_name != 'pull_request'

--- a/app/api/.env.example
+++ b/app/api/.env.example
@@ -22,5 +22,5 @@ BITS_DB_USERNAME=username
 BITS_DB_PWD=password
 
 # Playground now uses standalone LiteLLM proxy directly from the frontend.
-# Configure `VITE_PLAYGROUND_LITELLM_BASE_URL` and optional `VITE_PLAYGROUND_LITELLM_PROXY_KEY`
+# Configure `VITE_PLAYGROUND_LITELLM_BASE_URL` and `VITE_PLAYGROUND_LITELLM_SCOPE`
 # in app/frontend/.env(.example).

--- a/app/frontend/.env.example
+++ b/app/frontend/.env.example
@@ -27,8 +27,8 @@ VITE_PLAYGROUND_SHOW_CLOUD_SYNC_INDICATOR=false
 # Standalone LiteLLM proxy base URL (must include /v1).
 # Example: http://localhost:4000/v1 or https://my-litellm-proxy.example.com/v1
 VITE_PLAYGROUND_LITELLM_BASE_URL=http://localhost:4000/v1
-# Optional proxy key (Authorization: Bearer <key>) for standalone LiteLLM.
-VITE_PLAYGROUND_LITELLM_PROXY_KEY=
+# Delegated Entra scope accepted by the LiteLLM App Service Easy Auth endpoint.
+VITE_PLAYGROUND_LITELLM_SCOPE=
 # Optional explicit model sent to LiteLLM (for example: azure/gpt-4o).
 VITE_LITELLM_MODEL=
 # PMCOE blob container prefix used when current MCP payloads include filenames but omit source_path.

--- a/app/frontend/README.md
+++ b/app/frontend/README.md
@@ -41,7 +41,7 @@ Relevant env settings:
 
 ```bash
 VITE_PLAYGROUND_LITELLM_BASE_URL=http://localhost:4000/v1
-VITE_PLAYGROUND_LITELLM_PROXY_KEY=
+VITE_PLAYGROUND_LITELLM_SCOPE=api://<litellm-app-client-id>/user_impersonation
 VITE_LITELLM_MODEL=
 VITE_PMCOE_CONTAINER=pmcoe-sept-2025
 VITE_PLAYGROUND_ORCHESTRATOR_PREFLIGHT=true
@@ -49,7 +49,7 @@ VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 ```
 
 - `VITE_PLAYGROUND_LITELLM_BASE_URL`: standalone LiteLLM proxy base URL (must include `/v1`).
-- `VITE_PLAYGROUND_LITELLM_PROXY_KEY`: optional bearer token (LiteLLM master key) used for proxy auth.
+- `VITE_PLAYGROUND_LITELLM_SCOPE`: delegated Entra scope accepted by LiteLLM App Service Easy Auth.
 - `VITE_LITELLM_MODEL`: optional provider-scoped model id (for example `azure/gpt-4o-mini`).
 - `VITE_PMCOE_CONTAINER`: PMCOE blob container prefix used when the current Responses/MCP payload contains a document filename but omits `source_path`.
 - If `VITE_LITELLM_MODEL` is empty, model selection follows standalone LiteLLM config defaults.

--- a/app/frontend/src/playground/services/providers/azureOpenAIProvider.ts
+++ b/app/frontend/src/playground/services/providers/azureOpenAIProvider.ts
@@ -6,6 +6,7 @@
  */
 
 import OpenAI from "openai";
+import { msalInstance } from "../../../index";
 import { CompletionProvider, CompletionRequest, StreamingCallbacks, CompletionResult, CompletionMessage } from "../completionService";
 import { ResponseInput, Tool } from "openai/resources/responses/responses.mjs";
 import {
@@ -204,13 +205,27 @@ export class AzureOpenAIProvider implements CompletionProvider {
     return base.replace(/\/$/, "");
   }
 
-  /**
-   * Build an OpenAI-compatible client for standalone LiteLLM proxy.
-   * Uses dedicated proxy key when configured, otherwise falls back to user token.
-   */
-  private createClient(userToken: string): OpenAI {
-    const proxyKey = String(import.meta.env.VITE_PLAYGROUND_LITELLM_PROXY_KEY || "").trim();
-    const authToken = proxyKey.length > 0 ? proxyKey : userToken.trim();
+  private async getLiteLLMToken(fallbackToken: string): Promise<string> {
+    const scope = String(import.meta.env.VITE_PLAYGROUND_LITELLM_SCOPE || "").trim();
+    if (!scope) {
+      return fallbackToken.trim();
+    }
+
+    const account = msalInstance.getActiveAccount();
+    if (!account) {
+      throw new Error("No active account is available for LiteLLM authentication.");
+    }
+
+    const response = await msalInstance.acquireTokenSilent({
+      account,
+      scopes: [scope],
+    });
+    return response.accessToken;
+  }
+
+  /** Build an OpenAI-compatible client for standalone LiteLLM proxy. */
+  private async createClient(userToken: string): Promise<OpenAI> {
+    const authToken = await this.getLiteLLMToken(userToken);
     const defaultHeaders = {
       "Authorization": "Bearer " + authToken,
       "x-caller-system": "ssc-assistant",
@@ -286,7 +301,7 @@ export class AzureOpenAIProvider implements CompletionProvider {
     try {
       const updatedMessages = this.convertMessagesToInput(messages);
 
-      const client = this.createClient(userToken);
+      const client = await this.createClient(userToken);
 
       const stream = await client.responses.stream({
         model: model,


### PR DESCRIPTION
Implemented the Easy Auth migration.

Added opt-in App Service Easy Auth and keyless LiteLLM config in config.easy_auth.yaml and Terraform.
SSC Assistant playground and admin dashboard now acquire LiteLLM-scoped MSAL tokens; no browser-side proxy key remains.

MCP server now uses DefaultAzureCredential with ORCHESTRATOR_LITELLM_SCOPE.
Removed static-key CI/build/env guidance and updated runbooks.
Rotating the old LiteLLM master key remains required before production cutover

related PR:
https://github.com/dto-btn/ssca-mcp-server/pull/11
https://github.com/dto-btn/litellm-proxy-standalone/pull/5